### PR TITLE
Model Classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Other ###
+*dev.properties

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,15 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -58,6 +67,18 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/snodgrass/fifa_api/model/Event.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/Event.java
@@ -1,0 +1,79 @@
+package com.snodgrass.fifa_api.model;
+
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "events")
+@Getter
+@Setter
+public class Event {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "match_number", nullable = false)
+    private Integer matchNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Stage stage;
+
+    @Enumerated(EnumType.STRING)
+    private Group groupLetter;
+
+    @ManyToOne
+    @JoinColumn(name = "home_team_id")
+    private Team homeTeam;
+
+    @ManyToOne
+    @JoinColumn(name = "away_team_id")
+    private Team awayTeam;
+
+    private String homeTeamPlaceholder;
+    private String awayTeamPlaceholder;
+
+    @Column(name = "match_date", nullable = false)
+    private LocalDate matchDate;
+
+    private LocalTime kickoffTime;
+    private LocalDateTime kickoffUtc;
+
+    @Column(name = "arena_name", nullable = false)
+    private String arenaName;
+
+    @Column(nullable = false)
+    private String city;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MatchStatus status;
+
+    @Column(name = "match_state", columnDefinition = "JSON")
+    private String matchState;
+
+    private Integer homeScore;
+    private Integer awayScore;
+
+    @ManyToOne
+    @JoinColumn(name = "winner_team_id")
+    private Team winnerTeam;
+
+    private Boolean isDraw;
+    private boolean hasExtraTime;
+    private boolean hasPenalties;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/snodgrass/fifa_api/model/Team.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/Team.java
@@ -1,0 +1,45 @@
+package com.snodgrass.fifa_api.model;
+
+import com.snodgrass.fifa_api.model.enums.Group;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "teams")
+@Getter
+@Setter
+public class Team {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "country_name", nullable = false)
+    private String countryName;
+
+    @Column(name = "country_code", nullable = false)
+    private String countryCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "group_letter", nullable = false)
+    private Group groupLetter;
+
+    @Column(name = "squad", columnDefinition = "JSON")
+    private String squad;
+
+    @Embedded
+    private TeamStats stats;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    private String flagUrl;
+    private String logoUrl;
+    private Integer fifaRanking;
+    private String managerName;
+}

--- a/src/main/java/com/snodgrass/fifa_api/model/TeamStats.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/TeamStats.java
@@ -1,0 +1,22 @@
+package com.snodgrass.fifa_api.model;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+public class TeamStats {
+    private int matchesPlayed;
+    private int wins;
+    private int draws;
+    private int losses;
+    private int goalsFor;
+    private int goalsAgainst;
+    private int goalDifference;
+    private int groupPoints;
+    private int yellowCards;
+    private int redCards;
+    private boolean eliminated;
+}

--- a/src/main/java/com/snodgrass/fifa_api/model/enums/Group.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/enums/Group.java
@@ -1,0 +1,16 @@
+package com.snodgrass.fifa_api.model.enums;
+
+public enum Group {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L
+}

--- a/src/main/java/com/snodgrass/fifa_api/model/enums/MatchStatus.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/enums/MatchStatus.java
@@ -1,0 +1,10 @@
+package com.snodgrass.fifa_api.model.enums;
+
+public enum MatchStatus {
+    SCHEDULED,
+    IN_PROGRESS,
+    HALFTIME,
+    FINISHED,
+    POSTPONED,
+    CANCELLED
+}

--- a/src/main/java/com/snodgrass/fifa_api/model/enums/Stage.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/enums/Stage.java
@@ -1,0 +1,11 @@
+package com.snodgrass.fifa_api.model.enums;
+
+public enum Stage {
+    GROUP,
+    ROUND_OF_32,
+    ROUND_OF_16,
+    QUARTERFINAL,
+    SEMIFINAL,
+    THIRD_PLACE,
+    FINAL
+}

--- a/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
+++ b/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.snodgrass.fifa_api.repository;
+
+import com.snodgrass.fifa_api.model.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/snodgrass/fifa_api/repository/TeamRepository.java
+++ b/src/main/java/com/snodgrass/fifa_api/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package com.snodgrass.fifa_api.repository;
+
+import com.snodgrass.fifa_api.model.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=fifa-api
+
+# Database
+spring.datasource.url=jdbc:mysql://localhost:3306/fifa_world_cup
+spring.datasource.username=root
+spring.datasource.password=${DB_PASSWORD}

--- a/src/test/java/com/snodgrass/fifa_api/EventRepositoryTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/EventRepositoryTests.java
@@ -1,0 +1,24 @@
+package com.snodgrass.fifa_api;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.repository.EventRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@SpringBootTest
+public class EventRepositoryTests {
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Test
+    void shouldLoadEvents() {
+        List<Event> events = eventRepository.findAll();
+        assertFalse(events.isEmpty());
+        System.out.println(events.getFirst().getMatchDate());
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/TeamRepositoryTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/TeamRepositoryTests.java
@@ -1,0 +1,24 @@
+package com.snodgrass.fifa_api;
+
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.repository.TeamRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@SpringBootTest
+public class TeamRepositoryTests {
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Test
+    public void shouldLoadTeams() {
+        List<Team> teams = teamRepository.findAll();
+        assertThat(teams).isNotEmpty();
+        System.out.println(teams.getFirst().getCountryName());
+    }
+}


### PR DESCRIPTION
- Added Starter JPA for model data annotations
- Added Lombak for Getter and Setter annotations
    - Added maven plugin to set Lombak as an annotation processor
- Added `Event` and `Team` model class
    - Separated out `TeamStats` for future API response formatting reasons, added as `Embedded` in `Team`
- Added `Group`, `MatchStatus`, and `Stage` enums
- Added very basic repo classes: `EventRepository` & `TeamRepository` for `findAll()` for tests
- Added very basic test classes: `EventRepositoryTests` & `TeamRepositoryTests` to do basic integration tests to make sure the models worked, will expand in the future