### PR TITLE
Adding Services, Controllers, and Exception Handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
@@ -1,0 +1,26 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/events")
+@RequiredArgsConstructor
+public class EventController {
+    private final EventService eventService;
+
+    @GetMapping
+    public ResponseEntity<List<Event>> getAllEvents() {
+        return ResponseEntity.ok(eventService.getAllEvents());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Event> getEventById(@PathVariable Long id) {
+        return ResponseEntity.ok(eventService.getEventById(id));
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,0 +1,27 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+    private final TeamService teamService;
+
+    @GetMapping
+    public ResponseEntity<List<Team>> getAllTeams() {
+        return ResponseEntity.ok(teamService.getAllTeams());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Team> getTeamById(@PathVariable Long id) {
+        return ResponseEntity.ok(teamService.getTeamById(id));
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/exception/ErrorResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/exception/ErrorResponse.java
@@ -1,0 +1,5 @@
+package com.snodgrass.fifa_api.exception;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(int status, String message, LocalDateTime timestamp) {}

--- a/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.snodgrass.fifa_api.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(404, ex.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneric(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(500, "An unexpected error occurred", LocalDateTime.now()));
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/service/EventService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/EventService.java
@@ -1,0 +1,24 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.repository.EventRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+    private final EventRepository eventRepository;
+
+    public List<Event> getAllEvents() {
+        return eventRepository.findAll();
+    }
+
+    public Event getEventById(Long id) {
+        return eventRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Event not found with id: " + id));
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
@@ -1,0 +1,24 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.repository.TeamRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+    private final TeamRepository teamRepository;
+
+    public List<Team> getAllTeams() {
+        return teamRepository.findAll();
+    }
+
+    public Team getTeamById(Long id) {
+        return teamRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Team not found with id: " + id));
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -1,0 +1,80 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.exception.ErrorResponse;
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ControllerIntegrationTests {
+    @LocalServerPort
+    private int port;
+
+    private RestClient restClient;
+
+    @BeforeEach
+    void setUp() {
+        restClient = RestClient.create("http://localhost:" + port);
+    }
+
+    // Team
+    @Test
+    void getAllTeams_returns200WithNonEmptyList() {
+        ResponseEntity<List<Team>> response = restClient.get()
+                .uri("/api/teams")
+                .retrieve()
+                .toEntity(new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void getTeamById_returns404_whenNotFound() {
+        ResponseEntity<ErrorResponse> response = restClient.get()
+                .uri("/api/teams/999999")
+                .retrieve()
+                .onStatus(status -> status.value() == 404, (req, res) -> {})
+                .toEntity(ErrorResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).contains("999999");
+    }
+
+    // Event
+    @Test
+    void getAllEvents_returns200WithNonEmptyList() {
+        ResponseEntity<List<Event>> response = restClient.get()
+                .uri("/api/events")
+                .retrieve()
+                .toEntity(new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void getEventById_returns404_whenNotFound() {
+        ResponseEntity<ErrorResponse> response = restClient.get()
+                .uri("/api/events/999999")
+                .retrieve()
+                .onStatus(status -> status.value() == 404, (req, res) -> {})
+                .toEntity(ErrorResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).contains("999999");
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
@@ -1,0 +1,90 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import com.snodgrass.fifa_api.service.EventService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventControllerTests {
+    @Mock
+    private EventService eventService;
+
+    @InjectMocks
+    private EventController eventController;
+
+    private Event event;
+
+    @BeforeEach
+    void setUp() {
+        event = new Event();
+        event.setId(1L);
+        event.setMatchNumber(1);
+        event.setStage(Stage.GROUP);
+        event.setArenaName("Lusail Stadium");
+        event.setCity("Lusail");
+        event.setMatchDate(LocalDate.of(2026, 6, 11));
+        event.setStatus(MatchStatus.SCHEDULED);
+        event.setCreatedAt(LocalDateTime.now());
+        event.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getAllEvents_returns200WithList() {
+        when(eventService.getAllEvents()).thenReturn(List.of(event));
+
+        ResponseEntity<List<Event>> response = eventController.getAllEvents();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getArenaName()).isEqualTo("Lusail Stadium");
+    }
+
+    @Test
+    void getAllEvents_returns200WithEmptyList_whenNoEvents() {
+        when(eventService.getAllEvents()).thenReturn(List.of());
+
+        ResponseEntity<List<Event>> response = eventController.getAllEvents();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void getEventById_returns200_whenFound() {
+        when(eventService.getEventById(1L)).thenReturn(event);
+
+        ResponseEntity<Event> response = eventController.getEventById(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assert response.getBody() != null;
+        assertThat(response.getBody().getId()).isEqualTo(1L);
+        assertThat(response.getBody().getMatchNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void getEventById_throwsEntityNotFoundException_whenNotFound() {
+        when(eventService.getEventById(99L)).thenThrow(new EntityNotFoundException("Event not found with id: 99"));
+
+        assertThatThrownBy(() -> eventController.getEventById(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -1,0 +1,85 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.service.TeamService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamControllerTests {
+    @Mock
+    private TeamService teamService;
+
+    @InjectMocks
+    private TeamController teamController;
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = new Team();
+        team.setId(1L);
+        team.setCountryName("Brazil");
+        team.setCountryCode("BRA");
+        team.setGroupLetter(Group.A);
+        team.setCreatedAt(LocalDateTime.now());
+        team.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getAllTeams_returns200WithList() {
+        when(teamService.getAllTeams()).thenReturn(List.of(team));
+
+        ResponseEntity<List<Team>> response = teamController.getAllTeams();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getCountryName()).isEqualTo("Brazil");
+    }
+
+    @Test
+    void getAllTeams_returns200WithEmptyList_whenNoTeams() {
+        when(teamService.getAllTeams()).thenReturn(List.of());
+
+        ResponseEntity<List<Team>> response = teamController.getAllTeams();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void getTeamById_returns200_whenFound() {
+        when(teamService.getTeamById(1L)).thenReturn(team);
+
+        ResponseEntity<Team> response = teamController.getTeamById(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assert response.getBody() != null;
+        assertThat(response.getBody().getId()).isEqualTo(1L);
+        assertThat(response.getBody().getCountryName()).isEqualTo("Brazil");
+    }
+
+    @Test
+    void getTeamById_throwsEntityNotFoundException_whenNotFound() {
+        when(teamService.getTeamById(99L)).thenThrow(new EntityNotFoundException("Team not found with id: 99"));
+
+        assertThatThrownBy(() -> teamController.getTeamById(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/repository/EventRepositoryTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/repository/EventRepositoryTests.java
@@ -1,7 +1,6 @@
-package com.snodgrass.fifa_api;
+package com.snodgrass.fifa_api.repository;
 
 import com.snodgrass.fifa_api.model.Event;
-import com.snodgrass.fifa_api.repository.EventRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +18,5 @@ public class EventRepositoryTests {
     void shouldLoadEvents() {
         List<Event> events = eventRepository.findAll();
         assertFalse(events.isEmpty());
-        System.out.println(events.getFirst().getMatchDate());
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/repository/TeamRepositoryTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/repository/TeamRepositoryTests.java
@@ -1,7 +1,6 @@
-package com.snodgrass.fifa_api;
+package com.snodgrass.fifa_api.repository;
 
 import com.snodgrass.fifa_api.model.Team;
-import com.snodgrass.fifa_api.repository.TeamRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +18,5 @@ public class TeamRepositoryTests {
     public void shouldLoadTeams() {
         List<Team> teams = teamRepository.findAll();
         assertThat(teams).isNotEmpty();
-        System.out.println(teams.getFirst().getCountryName());
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
@@ -1,0 +1,87 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import com.snodgrass.fifa_api.repository.EventRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTests {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    private Event event;
+
+    @BeforeEach
+    void setUp() {
+        event = new Event();
+        event.setId(1L);
+        event.setMatchNumber(1);
+        event.setStage(Stage.GROUP);
+        event.setArenaName("Lusail Stadium");
+        event.setCity("Lusail");
+        event.setMatchDate(LocalDate.of(2026, 6, 11));
+        event.setStatus(MatchStatus.SCHEDULED);
+        event.setCreatedAt(LocalDateTime.now());
+        event.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getAllEvents_returnsAllEvents() {
+        when(eventRepository.findAll()).thenReturn(List.of(event));
+
+        List<Event> result = eventService.getAllEvents();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getArenaName()).isEqualTo("Lusail Stadium");
+        verify(eventRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAllEvents_returnsEmptyList_whenNoEvents() {
+        when(eventRepository.findAll()).thenReturn(List.of());
+
+        List<Event> result = eventService.getAllEvents();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getEventById_returnsEvent_whenFound() {
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+
+        Event result = eventService.getEventById(1L);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getMatchNumber()).isEqualTo(1);
+    }
+
+    @Test
+    void getEventById_throwsEntityNotFoundException_whenNotFound() {
+        when(eventRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.getEventById(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/service/TeamServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/TeamServiceTests.java
@@ -1,0 +1,82 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.repository.TeamRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTests {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = new Team();
+        team.setId(1L);
+        team.setCountryName("Brazil");
+        team.setCountryCode("BRA");
+        team.setGroupLetter(Group.A);
+        team.setCreatedAt(LocalDateTime.now());
+        team.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getAllTeams_returnsAllTeams() {
+        when(teamRepository.findAll()).thenReturn(List.of(team));
+
+        List<Team> result = teamService.getAllTeams();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCountryName()).isEqualTo("Brazil");
+        verify(teamRepository, times(1)).findAll();
+    }
+
+    @Test
+    void getAllTeams_returnsEmptyList_whenNoTeams() {
+        when(teamRepository.findAll()).thenReturn(List.of());
+
+        List<Team> result = teamService.getAllTeams();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getTeamById_returnsTeam_whenFound() {
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(team));
+
+        Team result = teamService.getTeamById(1L);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getCountryName()).isEqualTo("Brazil");
+    }
+
+    @Test
+    void getTeamById_throwsEntityNotFoundException_whenNotFound() {
+        when(teamRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> teamService.getTeamById(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+}


### PR DESCRIPTION
- Replaced `spring-boot-starter-webmvc-test` with `spring-boot-starter-test` for proper test support                                                                                                             
- Added `TeamService` & `EventService` with `getAll` and `getById` methods
  - `getById` throws `EntityNotFoundException` if record not found                                                                                                                                               
- Added `TeamController` & `EventController` as read-only REST controllers                                                                                                                                       
  - `GET /api/teams`, `GET /api/teams/{id}`                                                                                                                                                                      
  - `GET /api/events`, `GET /api/events/{id}`             
- Added `GlobalExceptionHandler` with `@RestControllerAdvice`
  - Maps `EntityNotFoundException` to 404 with a structured `ErrorResponse`
  - Generic fallback handler for unexpected 500 errors
- Added unit tests for services and controllers using Mockito
- Added `ControllerIntegrationTests` for end-to-end HTTP testing against a live app context
- Moved repository tests into a `repository` sub-package to match structure
