### PR TITLE
Adding more repository queries

### DIFF
--- a/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
@@ -1,7 +1,11 @@
 package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
 import com.snodgrass.fifa_api.service.EventService;
+import com.snodgrass.fifa_api.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EventController {
     private final EventService eventService;
+    private final TeamService teamService;
 
     @GetMapping
     public ResponseEntity<List<Event>> getAllEvents() {
@@ -22,5 +27,25 @@ public class EventController {
     @GetMapping("/{id}")
     public ResponseEntity<Event> getEventById(@PathVariable Long id) {
         return ResponseEntity.ok(eventService.getEventById(id));
+    }
+
+    @GetMapping("/group/{group}")
+    public ResponseEntity<List<Event>> getEventsByGroup(@PathVariable Group group) {
+        return ResponseEntity.ok(eventService.getEventsByGroup(group));
+    }
+
+    @GetMapping("/stage/{stage}")
+    public ResponseEntity<List<Event>> getEventsByStage(@PathVariable Stage stage) {
+        return ResponseEntity.ok(eventService.getEventsByStage(stage));
+    }
+
+    @GetMapping("/status/{status}")
+    public ResponseEntity<List<Event>> getEventsByStatus(@PathVariable MatchStatus status) {
+        return ResponseEntity.ok(eventService.getEventsByStatus(status));
+    }
+
+    @GetMapping("/team/{teamId}")
+    public ResponseEntity<List<Event>> getEventsByTeam(@PathVariable Long teamId) {
+        return ResponseEntity.ok(eventService.getEventsByTeam(teamService.getTeamById(teamId)));
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,9 +1,9 @@
 package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,5 +23,10 @@ public class TeamController {
     @GetMapping("/{id}")
     public ResponseEntity<Team> getTeamById(@PathVariable Long id) {
         return ResponseEntity.ok(teamService.getTeamById(id));
+    }
+
+    @GetMapping("/group/{group}")
+    public ResponseEntity<List<Team>> getTeamsByGroup(@PathVariable Group group) {
+        return ResponseEntity.ok(teamService.getTeamsByGroup(group));
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
+++ b/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
@@ -1,7 +1,17 @@
 package com.snodgrass.fifa_api.repository;
 
 import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EventRepository extends JpaRepository<Event, Long> {
+    List<Event> findByGroupLetter(Group group);
+    List<Event> findByStage(Stage stage);
+    List<Event> findByStatus(MatchStatus status);
+    List<Event> findByHomeTeamOrAwayTeam(Team homeTeam, Team awayTeam);
 }

--- a/src/main/java/com/snodgrass/fifa_api/repository/TeamRepository.java
+++ b/src/main/java/com/snodgrass/fifa_api/repository/TeamRepository.java
@@ -1,7 +1,11 @@
 package com.snodgrass.fifa_api.repository;
 
 import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    List<Team> findByGroupLetter(Group group);
 }

--- a/src/main/java/com/snodgrass/fifa_api/service/EventService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/EventService.java
@@ -1,6 +1,10 @@
 package com.snodgrass.fifa_api.service;
 
 import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
 import com.snodgrass.fifa_api.repository.EventRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +24,21 @@ public class EventService {
     public Event getEventById(Long id) {
         return eventRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Event not found with id: " + id));
+    }
+
+    public List<Event> getEventsByGroup(Group group) {
+        return eventRepository.findByGroupLetter(group);
+    }
+
+    public List<Event> getEventsByStage(Stage stage) {
+        return eventRepository.findByStage(stage);
+    }
+
+    public List<Event> getEventsByStatus(MatchStatus status) {
+        return eventRepository.findByStatus(status);
+    }
+
+    public List<Event> getEventsByTeam(Team team) {
+        return eventRepository.findByHomeTeamOrAwayTeam(team, team);
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
@@ -1,6 +1,7 @@
 package com.snodgrass.fifa_api.service;
 
 import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +21,9 @@ public class TeamService {
     public Team getTeamById(Long id) {
         return teamRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Team not found with id: " + id));
+    }
+
+    public List<Team> getTeamsByGroup(Group group) {
+        return teamRepository.findByGroupLetter(group);
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
@@ -1,9 +1,12 @@
 package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;
 import com.snodgrass.fifa_api.service.EventService;
+import com.snodgrass.fifa_api.service.TeamService;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,17 +30,31 @@ class EventControllerTests {
     @Mock
     private EventService eventService;
 
+    @Mock
+    private TeamService teamService;
+
     @InjectMocks
     private EventController eventController;
 
+    private Team team;
     private Event event;
 
     @BeforeEach
     void setUp() {
+        team = new Team();
+        team.setId(1L);
+        team.setCountryName("Brazil");
+        team.setCountryCode("BRA");
+        team.setGroupLetter(Group.A);
+        team.setCreatedAt(LocalDateTime.now());
+        team.setUpdatedAt(LocalDateTime.now());
+
         event = new Event();
         event.setId(1L);
         event.setMatchNumber(1);
         event.setStage(Stage.GROUP);
+        event.setGroupLetter(Group.A);
+        event.setHomeTeam(team);
         event.setArenaName("Lusail Stadium");
         event.setCity("Lusail");
         event.setMatchDate(LocalDate.of(2026, 6, 11));
@@ -84,6 +101,89 @@ class EventControllerTests {
         when(eventService.getEventById(99L)).thenThrow(new EntityNotFoundException("Event not found with id: 99"));
 
         assertThatThrownBy(() -> eventController.getEventById(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void getEventsByGroup_returns200WithList() {
+        when(eventService.getEventsByGroup(Group.A)).thenReturn(List.of(event));
+
+        ResponseEntity<List<Event>> response = eventController.getEventsByGroup(Group.A);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getGroupLetter()).isEqualTo(Group.A);
+    }
+
+    @Test
+    void getEventsByGroup_returns200WithEmptyList_whenNoEventsInGroup() {
+        when(eventService.getEventsByGroup(Group.B)).thenReturn(List.of());
+
+        ResponseEntity<List<Event>> response = eventController.getEventsByGroup(Group.B);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void getEventsByStage_returns200WithList() {
+        when(eventService.getEventsByStage(Stage.GROUP)).thenReturn(List.of(event));
+
+        ResponseEntity<List<Event>> response = eventController.getEventsByStage(Stage.GROUP);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getStage()).isEqualTo(Stage.GROUP);
+    }
+
+    @Test
+    void getEventsByStage_returns200WithEmptyList_whenNoEventsForStage() {
+        when(eventService.getEventsByStage(Stage.FINAL)).thenReturn(List.of());
+
+        ResponseEntity<List<Event>> response = eventController.getEventsByStage(Stage.FINAL);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void getEventsByStatus_returns200WithList() {
+        when(eventService.getEventsByStatus(MatchStatus.SCHEDULED)).thenReturn(List.of(event));
+
+        ResponseEntity<List<Event>> response = eventController.getEventsByStatus(MatchStatus.SCHEDULED);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getStatus()).isEqualTo(MatchStatus.SCHEDULED);
+    }
+
+    @Test
+    void getEventsByStatus_returns200WithEmptyList_whenNoEventsForStatus() {
+        when(eventService.getEventsByStatus(MatchStatus.FINISHED)).thenReturn(List.of());
+
+        ResponseEntity<List<Event>> response = eventController.getEventsByStatus(MatchStatus.FINISHED);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void getEventsByTeam_returns200WithList() {
+        when(teamService.getTeamById(1L)).thenReturn(team);
+        when(eventService.getEventsByTeam(team)).thenReturn(List.of(event));
+
+        ResponseEntity<List<Event>> response = eventController.getEventsByTeam(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+    }
+
+    @Test
+    void getEventsByTeam_throwsEntityNotFoundException_whenTeamNotFound() {
+        when(teamService.getTeamById(99L)).thenThrow(new EntityNotFoundException("Team not found with id: 99"));
+
+        assertThatThrownBy(() -> eventController.getEventsByTeam(99L))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("99");
     }

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -82,4 +82,25 @@ class TeamControllerTests {
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("99");
     }
+
+    @Test
+    void getTeamsByGroup_returns200WithList() {
+        when(teamService.getTeamsByGroup(Group.A)).thenReturn(List.of(team));
+
+        ResponseEntity<List<Team>> response = teamController.getTeamsByGroup(Group.A);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().getFirst().getGroupLetter()).isEqualTo(Group.A);
+    }
+
+    @Test
+    void getTeamsByGroup_returns200WithEmptyList_whenNoTeamsInGroup() {
+        when(teamService.getTeamsByGroup(Group.B)).thenReturn(List.of());
+
+        ResponseEntity<List<Team>> response = teamController.getTeamsByGroup(Group.B);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
 }

--- a/src/test/java/com/snodgrass/fifa_api/repository/EventRepositoryTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/repository/EventRepositoryTests.java
@@ -1,12 +1,17 @@
 package com.snodgrass.fifa_api.repository;
 
 import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @SpringBootTest
@@ -14,9 +19,44 @@ public class EventRepositoryTests {
     @Autowired
     private EventRepository eventRepository;
 
+    @Autowired
+    private TeamRepository teamRepository;
+
     @Test
     void shouldLoadEvents() {
         List<Event> events = eventRepository.findAll();
         assertFalse(events.isEmpty());
+    }
+
+    @Test
+    void findByGroupLetter_returnsEventsInGroup() {
+        List<Event> events = eventRepository.findByGroupLetter(Group.A);
+        assertThat(events).isNotEmpty();
+        assertThat(events).allMatch(e -> e.getGroupLetter() == Group.A);
+    }
+
+    @Test
+    void findByStage_returnsEventsByStage() {
+        List<Event> events = eventRepository.findByStage(Stage.GROUP);
+        assertThat(events).isNotEmpty();
+        assertThat(events).allMatch(e -> e.getStage() == Stage.GROUP);
+    }
+
+    @Test
+    void findByStatus_returnsEventsByStatus() {
+        List<Event> events = eventRepository.findByStatus(MatchStatus.SCHEDULED);
+        assertThat(events).isNotEmpty();
+        assertThat(events).allMatch(e -> e.getStatus() == MatchStatus.SCHEDULED);
+    }
+
+    @Test
+    void findByHomeTeamOrAwayTeam_returnsMatchHistory() {
+        Team team = teamRepository.findAll().getFirst();
+        List<Event> events = eventRepository.findByHomeTeamOrAwayTeam(team, team);
+        assertThat(events).isNotEmpty();
+        assertThat(events).allMatch(e ->
+                e.getHomeTeam().getId().equals(team.getId()) ||
+                e.getAwayTeam().getId().equals(team.getId())
+        );
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/repository/TeamRepositoryTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/repository/TeamRepositoryTests.java
@@ -1,6 +1,7 @@
 package com.snodgrass.fifa_api.repository;
 
 import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,5 +19,12 @@ public class TeamRepositoryTests {
     public void shouldLoadTeams() {
         List<Team> teams = teamRepository.findAll();
         assertThat(teams).isNotEmpty();
+    }
+
+    @Test
+    void findByGroupLetter_returnsTeamsInGroup() {
+        List<Team> teams = teamRepository.findByGroupLetter(Group.A);
+        assertThat(teams).isNotEmpty();
+        assertThat(teams).allMatch(t -> t.getGroupLetter() == Group.A);
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
@@ -1,6 +1,8 @@
 package com.snodgrass.fifa_api.service;
 
 import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;
 import com.snodgrass.fifa_api.repository.EventRepository;
@@ -38,6 +40,7 @@ class EventServiceTests {
         event.setId(1L);
         event.setMatchNumber(1);
         event.setStage(Stage.GROUP);
+        event.setGroupLetter(Group.A);
         event.setArenaName("Lusail Stadium");
         event.setCity("Lusail");
         event.setMatchDate(LocalDate.of(2026, 6, 11));
@@ -83,5 +86,84 @@ class EventServiceTests {
         assertThatThrownBy(() -> eventService.getEventById(99L))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("99");
+    }
+
+    @Test
+    void getEventsByGroup_returnsEventsInGroup() {
+        when(eventRepository.findByGroupLetter(Group.A)).thenReturn(List.of(event));
+
+        List<Event> result = eventService.getEventsByGroup(Group.A);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getGroupLetter()).isEqualTo(Group.A);
+    }
+
+    @Test
+    void getEventsByGroup_returnsEmptyList_whenNoEventsInGroup() {
+        when(eventRepository.findByGroupLetter(Group.B)).thenReturn(List.of());
+
+        List<Event> result = eventService.getEventsByGroup(Group.B);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getEventsByStage_returnsEventsByStage() {
+        when(eventRepository.findByStage(Stage.GROUP)).thenReturn(List.of(event));
+
+        List<Event> result = eventService.getEventsByStage(Stage.GROUP);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getStage()).isEqualTo(Stage.GROUP);
+    }
+
+    @Test
+    void getEventsByStage_returnsEmptyList_whenNoEventsForStage() {
+        when(eventRepository.findByStage(Stage.FINAL)).thenReturn(List.of());
+
+        List<Event> result = eventService.getEventsByStage(Stage.FINAL);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getEventsByStatus_returnsEventsByStatus() {
+        when(eventRepository.findByStatus(MatchStatus.SCHEDULED)).thenReturn(List.of(event));
+
+        List<Event> result = eventService.getEventsByStatus(MatchStatus.SCHEDULED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getStatus()).isEqualTo(MatchStatus.SCHEDULED);
+    }
+
+    @Test
+    void getEventsByStatus_returnsEmptyList_whenNoEventsForStatus() {
+        when(eventRepository.findByStatus(MatchStatus.FINISHED)).thenReturn(List.of());
+
+        List<Event> result = eventService.getEventsByStatus(MatchStatus.FINISHED);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getEventsByTeam_returnsMatchHistory() {
+        Team team = new Team();
+        team.setId(1L);
+        when(eventRepository.findByHomeTeamOrAwayTeam(team, team)).thenReturn(List.of(event));
+
+        List<Event> result = eventService.getEventsByTeam(team);
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getEventsByTeam_returnsEmptyList_whenNoMatches() {
+        Team team = new Team();
+        team.setId(99L);
+        when(eventRepository.findByHomeTeamOrAwayTeam(team, team)).thenReturn(List.of());
+
+        List<Event> result = eventService.getEventsByTeam(team);
+
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/service/TeamServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/TeamServiceTests.java
@@ -79,4 +79,23 @@ class TeamServiceTests {
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("99");
     }
+
+    @Test
+    void getTeamsByGroup_returnsTeamsInGroup() {
+        when(teamRepository.findByGroupLetter(Group.A)).thenReturn(List.of(team));
+
+        List<Team> result = teamService.getTeamsByGroup(Group.A);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getGroupLetter()).isEqualTo(Group.A);
+    }
+
+    @Test
+    void getTeamsByGroup_returnsEmptyList_whenNoTeamsInGroup() {
+        when(teamRepository.findByGroupLetter(Group.B)).thenReturn(List.of());
+
+        List<Team> result = teamService.getTeamsByGroup(Group.B);
+
+        assertThat(result).isEmpty();
+    }
 }


### PR DESCRIPTION
- Added custom repository queries to `TeamRepository` & `EventRepository`                                                                                                                                        
  - `findByGroupLetter(Group group)` on both repos                                                                                                                                                               
  - `findByStage(Stage stage)` on `EventRepository`                                                                                                                                                              
  - `findByStatus(MatchStatus status)` on `EventRepository`                                                                                                                                                      
  - `findByHomeTeamOrAwayTeam(Team home, Team away)` on `EventRepository`                                                                                                                                        
- Wired new repository queries through service and controller layers                                                                                                                                             
  - `GET /api/teams/group/{group}`                                                                                                                                                                               
  - `GET /api/events/group/{group}`                                                                                                                                                                              
  - `GET /api/events/stage/{stage}`                                                                                                                                                                              
  - `GET /api/events/status/{status}`                                                                                                                                                                            
  - `GET /api/events/team/{teamId}`
- Expanded tests for all new queries across all layers
  - Repository integration tests to verify queries return correct filtered results
  - Service unit tests covering results and empty list cases
  - Controller unit tests covering results, empty list, and not found cases

