### PR TITLE
Adding response DTO classes

### DIFF
--- a/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
@@ -1,6 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.dto.EventResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;
@@ -20,32 +20,32 @@ public class EventController {
     private final TeamService teamService;
 
     @GetMapping
-    public ResponseEntity<List<Event>> getAllEvents() {
-        return ResponseEntity.ok(eventService.getAllEvents());
+    public ResponseEntity<List<EventResponse>> getAllEvents() {
+        return ResponseEntity.ok(eventService.getAllEvents().stream().map(EventResponse::from).toList());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Event> getEventById(@PathVariable Long id) {
-        return ResponseEntity.ok(eventService.getEventById(id));
+    public ResponseEntity<EventResponse> getEventById(@PathVariable Long id) {
+        return ResponseEntity.ok(EventResponse.from(eventService.getEventById(id)));
     }
 
     @GetMapping("/group/{group}")
-    public ResponseEntity<List<Event>> getEventsByGroup(@PathVariable Group group) {
-        return ResponseEntity.ok(eventService.getEventsByGroup(group));
+    public ResponseEntity<List<EventResponse>> getEventsByGroup(@PathVariable Group group) {
+        return ResponseEntity.ok(eventService.getEventsByGroup(group).stream().map(EventResponse::from).toList());
     }
 
     @GetMapping("/stage/{stage}")
-    public ResponseEntity<List<Event>> getEventsByStage(@PathVariable Stage stage) {
-        return ResponseEntity.ok(eventService.getEventsByStage(stage));
+    public ResponseEntity<List<EventResponse>> getEventsByStage(@PathVariable Stage stage) {
+        return ResponseEntity.ok(eventService.getEventsByStage(stage).stream().map(EventResponse::from).toList());
     }
 
     @GetMapping("/status/{status}")
-    public ResponseEntity<List<Event>> getEventsByStatus(@PathVariable MatchStatus status) {
-        return ResponseEntity.ok(eventService.getEventsByStatus(status));
+    public ResponseEntity<List<EventResponse>> getEventsByStatus(@PathVariable MatchStatus status) {
+        return ResponseEntity.ok(eventService.getEventsByStatus(status).stream().map(EventResponse::from).toList());
     }
 
     @GetMapping("/team/{teamId}")
-    public ResponseEntity<List<Event>> getEventsByTeam(@PathVariable Long teamId) {
-        return ResponseEntity.ok(eventService.getEventsByTeam(teamService.getTeamById(teamId)));
+    public ResponseEntity<List<EventResponse>> getEventsByTeam(@PathVariable Long teamId) {
+        return ResponseEntity.ok(eventService.getEventsByTeam(teamService.getTeamById(teamId)).stream().map(EventResponse::from).toList());
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,6 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.dto.TeamResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
 import lombok.RequiredArgsConstructor;
@@ -16,17 +16,17 @@ public class TeamController {
     private final TeamService teamService;
 
     @GetMapping
-    public ResponseEntity<List<Team>> getAllTeams() {
-        return ResponseEntity.ok(teamService.getAllTeams());
+    public ResponseEntity<List<TeamResponse>> getAllTeams() {
+        return ResponseEntity.ok(teamService.getAllTeams().stream().map(TeamResponse::from).toList());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Team> getTeamById(@PathVariable Long id) {
-        return ResponseEntity.ok(teamService.getTeamById(id));
+    public ResponseEntity<TeamResponse> getTeamById(@PathVariable Long id) {
+        return ResponseEntity.ok(TeamResponse.from(teamService.getTeamById(id)));
     }
 
     @GetMapping("/group/{group}")
-    public ResponseEntity<List<Team>> getTeamsByGroup(@PathVariable Group group) {
-        return ResponseEntity.ok(teamService.getTeamsByGroup(group));
+    public ResponseEntity<List<TeamResponse>> getTeamsByGroup(@PathVariable Group group) {
+        return ResponseEntity.ok(teamService.getTeamsByGroup(group).stream().map(TeamResponse::from).toList());
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/dto/EventResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/EventResponse.java
@@ -1,0 +1,58 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record EventResponse(
+        Long id,
+        Integer matchNumber,
+        Stage stage,
+        Group groupLetter,
+        TeamResponse homeTeam,
+        TeamResponse awayTeam,
+        String homeTeamPlaceholder,
+        String awayTeamPlaceholder,
+        LocalDate matchDate,
+        LocalTime kickoffTime,
+        LocalDateTime kickoffUtc,
+        String arenaName,
+        String city,
+        MatchStatus status,
+        Integer homeScore,
+        Integer awayScore,
+        TeamResponse winnerTeam,
+        Boolean isDraw,
+        boolean hasExtraTime,
+        boolean hasPenalties
+) {
+    public static EventResponse from(Event event) {
+        return new EventResponse(
+                event.getId(),
+                event.getMatchNumber(),
+                event.getStage(),
+                event.getGroupLetter(),
+                event.getHomeTeam() != null ? TeamResponse.from(event.getHomeTeam()) : null,
+                event.getAwayTeam() != null ? TeamResponse.from(event.getAwayTeam()) : null,
+                event.getHomeTeamPlaceholder(),
+                event.getAwayTeamPlaceholder(),
+                event.getMatchDate(),
+                event.getKickoffTime(),
+                event.getKickoffUtc(),
+                event.getArenaName(),
+                event.getCity(),
+                event.getStatus(),
+                event.getHomeScore(),
+                event.getAwayScore(),
+                event.getWinnerTeam() != null ? TeamResponse.from(event.getWinnerTeam()) : null,
+                event.getIsDraw(),
+                event.isHasExtraTime(),
+                event.isHasPenalties()
+        );
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/TeamResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/TeamResponse.java
@@ -1,0 +1,30 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
+
+public record TeamResponse(
+        Long id,
+        String countryName,
+        String countryCode,
+        Group groupLetter,
+        String flagUrl,
+        String logoUrl,
+        Integer fifaRanking,
+        String managerName,
+        TeamStatsResponse stats
+) {
+    public static TeamResponse from(Team team) {
+        return new TeamResponse(
+                team.getId(),
+                team.getCountryName(),
+                team.getCountryCode(),
+                team.getGroupLetter(),
+                team.getFlagUrl(),
+                team.getLogoUrl(),
+                team.getFifaRanking(),
+                team.getManagerName(),
+                TeamStatsResponse.from(team.getStats())
+        );
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/TeamStatsResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/TeamStatsResponse.java
@@ -1,0 +1,34 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.model.TeamStats;
+
+public record TeamStatsResponse(
+        int matchesPlayed,
+        int wins,
+        int draws,
+        int losses,
+        int goalsFor,
+        int goalsAgainst,
+        int goalDifference,
+        int groupPoints,
+        int yellowCards,
+        int redCards,
+        boolean eliminated
+) {
+    public static TeamStatsResponse from(TeamStats stats) {
+        if (stats == null) return null;
+        return new TeamStatsResponse(
+                stats.getMatchesPlayed(),
+                stats.getWins(),
+                stats.getDraws(),
+                stats.getLosses(),
+                stats.getGoalsFor(),
+                stats.getGoalsAgainst(),
+                stats.getGoalDifference(),
+                stats.getGroupPoints(),
+                stats.getYellowCards(),
+                stats.getRedCards(),
+                stats.isEliminated()
+        );
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -1,8 +1,8 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.EventResponse;
+import com.snodgrass.fifa_api.dto.TeamResponse;
 import com.snodgrass.fifa_api.exception.ErrorResponse;
-import com.snodgrass.fifa_api.model.Event;
-import com.snodgrass.fifa_api.model.Team;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,7 +31,7 @@ class ControllerIntegrationTests {
     // Team
     @Test
     void getAllTeams_returns200WithNonEmptyList() {
-        ResponseEntity<List<Team>> response = restClient.get()
+        ResponseEntity<List<TeamResponse>> response = restClient.get()
                 .uri("/api/teams")
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});
@@ -56,7 +56,7 @@ class ControllerIntegrationTests {
     // Event
     @Test
     void getAllEvents_returns200WithNonEmptyList() {
-        ResponseEntity<List<Event>> response = restClient.get()
+        ResponseEntity<List<EventResponse>> response = restClient.get()
                 .uri("/api/events")
                 .retrieve()
                 .toEntity(new ParameterizedTypeReference<>() {});

--- a/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.EventResponse;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
@@ -67,18 +68,18 @@ class EventControllerTests {
     void getAllEvents_returns200WithList() {
         when(eventService.getAllEvents()).thenReturn(List.of(event));
 
-        ResponseEntity<List<Event>> response = eventController.getAllEvents();
+        ResponseEntity<List<EventResponse>> response = eventController.getAllEvents();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().getFirst().getArenaName()).isEqualTo("Lusail Stadium");
+        assertThat(response.getBody().getFirst().arenaName()).isEqualTo("Lusail Stadium");
     }
 
     @Test
     void getAllEvents_returns200WithEmptyList_whenNoEvents() {
         when(eventService.getAllEvents()).thenReturn(List.of());
 
-        ResponseEntity<List<Event>> response = eventController.getAllEvents();
+        ResponseEntity<List<EventResponse>> response = eventController.getAllEvents();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEmpty();
@@ -88,12 +89,12 @@ class EventControllerTests {
     void getEventById_returns200_whenFound() {
         when(eventService.getEventById(1L)).thenReturn(event);
 
-        ResponseEntity<Event> response = eventController.getEventById(1L);
+        ResponseEntity<EventResponse> response = eventController.getEventById(1L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assert response.getBody() != null;
-        assertThat(response.getBody().getId()).isEqualTo(1L);
-        assertThat(response.getBody().getMatchNumber()).isEqualTo(1);
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().matchNumber()).isEqualTo(1);
     }
 
     @Test
@@ -109,18 +110,18 @@ class EventControllerTests {
     void getEventsByGroup_returns200WithList() {
         when(eventService.getEventsByGroup(Group.A)).thenReturn(List.of(event));
 
-        ResponseEntity<List<Event>> response = eventController.getEventsByGroup(Group.A);
+        ResponseEntity<List<EventResponse>> response = eventController.getEventsByGroup(Group.A);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().getFirst().getGroupLetter()).isEqualTo(Group.A);
+        assertThat(response.getBody().getFirst().groupLetter()).isEqualTo(Group.A);
     }
 
     @Test
     void getEventsByGroup_returns200WithEmptyList_whenNoEventsInGroup() {
         when(eventService.getEventsByGroup(Group.B)).thenReturn(List.of());
 
-        ResponseEntity<List<Event>> response = eventController.getEventsByGroup(Group.B);
+        ResponseEntity<List<EventResponse>> response = eventController.getEventsByGroup(Group.B);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEmpty();
@@ -130,18 +131,18 @@ class EventControllerTests {
     void getEventsByStage_returns200WithList() {
         when(eventService.getEventsByStage(Stage.GROUP)).thenReturn(List.of(event));
 
-        ResponseEntity<List<Event>> response = eventController.getEventsByStage(Stage.GROUP);
+        ResponseEntity<List<EventResponse>> response = eventController.getEventsByStage(Stage.GROUP);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().getFirst().getStage()).isEqualTo(Stage.GROUP);
+        assertThat(response.getBody().getFirst().stage()).isEqualTo(Stage.GROUP);
     }
 
     @Test
     void getEventsByStage_returns200WithEmptyList_whenNoEventsForStage() {
         when(eventService.getEventsByStage(Stage.FINAL)).thenReturn(List.of());
 
-        ResponseEntity<List<Event>> response = eventController.getEventsByStage(Stage.FINAL);
+        ResponseEntity<List<EventResponse>> response = eventController.getEventsByStage(Stage.FINAL);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEmpty();
@@ -151,18 +152,18 @@ class EventControllerTests {
     void getEventsByStatus_returns200WithList() {
         when(eventService.getEventsByStatus(MatchStatus.SCHEDULED)).thenReturn(List.of(event));
 
-        ResponseEntity<List<Event>> response = eventController.getEventsByStatus(MatchStatus.SCHEDULED);
+        ResponseEntity<List<EventResponse>> response = eventController.getEventsByStatus(MatchStatus.SCHEDULED);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().getFirst().getStatus()).isEqualTo(MatchStatus.SCHEDULED);
+        assertThat(response.getBody().getFirst().status()).isEqualTo(MatchStatus.SCHEDULED);
     }
 
     @Test
     void getEventsByStatus_returns200WithEmptyList_whenNoEventsForStatus() {
         when(eventService.getEventsByStatus(MatchStatus.FINISHED)).thenReturn(List.of());
 
-        ResponseEntity<List<Event>> response = eventController.getEventsByStatus(MatchStatus.FINISHED);
+        ResponseEntity<List<EventResponse>> response = eventController.getEventsByStatus(MatchStatus.FINISHED);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEmpty();
@@ -173,7 +174,7 @@ class EventControllerTests {
         when(teamService.getTeamById(1L)).thenReturn(team);
         when(eventService.getEventsByTeam(team)).thenReturn(List.of(event));
 
-        ResponseEntity<List<Event>> response = eventController.getEventsByTeam(1L);
+        ResponseEntity<List<EventResponse>> response = eventController.getEventsByTeam(1L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.TeamResponse;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
@@ -45,18 +46,18 @@ class TeamControllerTests {
     void getAllTeams_returns200WithList() {
         when(teamService.getAllTeams()).thenReturn(List.of(team));
 
-        ResponseEntity<List<Team>> response = teamController.getAllTeams();
+        ResponseEntity<List<TeamResponse>> response = teamController.getAllTeams();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().getFirst().getCountryName()).isEqualTo("Brazil");
+        assertThat(response.getBody().getFirst().countryName()).isEqualTo("Brazil");
     }
 
     @Test
     void getAllTeams_returns200WithEmptyList_whenNoTeams() {
         when(teamService.getAllTeams()).thenReturn(List.of());
 
-        ResponseEntity<List<Team>> response = teamController.getAllTeams();
+        ResponseEntity<List<TeamResponse>> response = teamController.getAllTeams();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEmpty();
@@ -66,12 +67,12 @@ class TeamControllerTests {
     void getTeamById_returns200_whenFound() {
         when(teamService.getTeamById(1L)).thenReturn(team);
 
-        ResponseEntity<Team> response = teamController.getTeamById(1L);
+        ResponseEntity<TeamResponse> response = teamController.getTeamById(1L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assert response.getBody() != null;
-        assertThat(response.getBody().getId()).isEqualTo(1L);
-        assertThat(response.getBody().getCountryName()).isEqualTo("Brazil");
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().countryName()).isEqualTo("Brazil");
     }
 
     @Test
@@ -87,18 +88,18 @@ class TeamControllerTests {
     void getTeamsByGroup_returns200WithList() {
         when(teamService.getTeamsByGroup(Group.A)).thenReturn(List.of(team));
 
-        ResponseEntity<List<Team>> response = teamController.getTeamsByGroup(Group.A);
+        ResponseEntity<List<TeamResponse>> response = teamController.getTeamsByGroup(Group.A);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
-        assertThat(response.getBody().getFirst().getGroupLetter()).isEqualTo(Group.A);
+        assertThat(response.getBody().getFirst().groupLetter()).isEqualTo(Group.A);
     }
 
     @Test
     void getTeamsByGroup_returns200WithEmptyList_whenNoTeamsInGroup() {
         when(teamService.getTeamsByGroup(Group.B)).thenReturn(List.of());
 
-        ResponseEntity<List<Team>> response = teamController.getTeamsByGroup(Group.B);
+        ResponseEntity<List<TeamResponse>> response = teamController.getTeamsByGroup(Group.B);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEmpty();


### PR DESCRIPTION
- Added response DTO classes to control API serialization                                            
    - `TeamStatsResponse` as a nested record within `TeamResponse`                                                                                                                                               
    - `TeamResponse` — exposes public fields, drops `squad`, `createdAt`, `updatedAt`                                                                                                                            
    - `EventResponse` — references `homeTeam`, `awayTeam`, and `winnerTeam` as `TeamResponse` instead of full entities, drops `matchState`, `createdAt`, `updatedAt`                                             
    - All DTOs use static `from()` factory methods for mapping from entities                                                                                                                                     
- Updated `TeamController` & `EventController` to return DTOs instead of raw entities                                                                                                                            
- Updated controller unit tests and integration tests to reflect DTO return types                                                                                                                                
    - Assertions updated to use record accessors instead of getters   