### PR TITLE
Adding OpenAPI docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+# FIFA World Cup 2026 API
+
+> This is a personal project to keep practicing creating RESTful APIs using Java. More will be added to this project for different applications I will be building with different tech stacks in the near future.
+
+A read-only REST API serving FIFA World Cup 2026 team and match (mock) data.
+
+---
+
+## Technology
+
+- **Java 25**
+- **Spring Boot 4.0.5**
+- **Spring Data JPA** — repository layer and ORM
+- **MySQL 8.0+** — database
+- **Lombok** — boilerplate reduction
+- **springdoc-openapi 3.0.2** — auto-generated API docs and Swagger UI
+
+---
+
+## Prerequisites
+
+- Java 25+
+- Maven
+- MySQL 8.0+
+- Python 3 with `mysql-connector-python` installed
+
+---
+
+## Setup
+
+### 1. Database
+
+The project includes a Python script that creates the database, tables, and seeds all data — 48 teams with full squads and 104 matches (72 group stage + 32 knockout). Match dates are generated dynamically starting from tomorrow relative to when the script is run.
+
+Install the required Python dependency:
+
+```bash
+pip install mysql-connector-python
+```
+
+Run the setup script:
+
+```bash
+python src/main/resources/tools/setup_worldcup.py
+```
+
+The script will prompt for your MySQL root password and handle everything else.
+
+### 2. Environment Variable
+
+The app reads the database password from an environment variable. Set it before running:
+
+```bash
+# macOS / Linux
+export DB_PASSWORD=your_mysql_password
+
+# Windows (Command Prompt)
+set DB_PASSWORD=your_mysql_password
+
+# Windows (PowerShell)
+$env:DB_PASSWORD="your_mysql_password"
+```
+
+### 3. Run the Application
+
+```bash
+./mvnw spring-boot:run
+```
+
+The API will start on `http://localhost:8080`.
+
+---
+
+## API Docs
+
+Once running, Swagger UI is available at:
+
+```
+http://localhost:8080/swagger-ui/index.html
+```
+
+Raw OpenAPI spec:
+
+```
+http://localhost:8080/v3/api-docs
+```
+
+---
+
+## Endpoints
+
+### Teams
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/teams` | Get all teams |
+| GET | `/api/teams/{id}` | Get team by ID |
+| GET | `/api/teams/group/{group}` | Get teams by group (A–L) |
+
+### Events
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/events` | Get all events |
+| GET | `/api/events/{id}` | Get event by ID |
+| GET | `/api/events/group/{group}` | Get events by group (A–L) |
+| GET | `/api/events/stage/{stage}` | Get events by stage |
+| GET | `/api/events/status/{status}` | Get events by status |
+| GET | `/api/events/team/{teamId}` | Get all events involving a team |
+
+**Stage values:** `GROUP`, `ROUND_OF_32`, `ROUND_OF_16`, `QUARTERFINAL`, `SEMIFINAL`, `THIRD_PLACE`, `FINAL`
+
+**Status values:** `SCHEDULED`, `IN_PROGRESS`, `HALFTIME`, `FINISHED`, `POSTPONED`, `CANCELLED`

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/snodgrass/fifa_api/config/OpenApiConfig.java
+++ b/src/main/java/com/snodgrass/fifa_api/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.snodgrass.fifa_api.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("FIFA World Cup 2026 API")
+                        .version("1.0.0")
+                        .description("Read-only API for FIFA World Cup 2026 teams and match (mock) data"));
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
@@ -6,6 +6,10 @@ import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;
 import com.snodgrass.fifa_api.service.EventService;
 import com.snodgrass.fifa_api.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,37 +19,51 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/events")
 @RequiredArgsConstructor
+@Tag(name = "Events", description = "Endpoints for retrieving World Cup match data")
 public class EventController {
     private final EventService eventService;
     private final TeamService teamService;
 
+    @Operation(summary = "Get all events")
     @GetMapping
     public ResponseEntity<List<EventResponse>> getAllEvents() {
         return ResponseEntity.ok(eventService.getAllEvents().stream().map(EventResponse::from).toList());
     }
 
+    @Operation(summary = "Get event by ID")
+    @ApiResponse(responseCode = "404", description = "Event not found")
     @GetMapping("/{id}")
-    public ResponseEntity<EventResponse> getEventById(@PathVariable Long id) {
+    public ResponseEntity<EventResponse> getEventById(
+            @Parameter(description = "Event ID") @PathVariable Long id) {
         return ResponseEntity.ok(EventResponse.from(eventService.getEventById(id)));
     }
 
+    @Operation(summary = "Get events by group")
     @GetMapping("/group/{group}")
-    public ResponseEntity<List<EventResponse>> getEventsByGroup(@PathVariable Group group) {
+    public ResponseEntity<List<EventResponse>> getEventsByGroup(
+            @Parameter(description = "Group letter (A-L)") @PathVariable Group group) {
         return ResponseEntity.ok(eventService.getEventsByGroup(group).stream().map(EventResponse::from).toList());
     }
 
+    @Operation(summary = "Get events by stage")
     @GetMapping("/stage/{stage}")
-    public ResponseEntity<List<EventResponse>> getEventsByStage(@PathVariable Stage stage) {
+    public ResponseEntity<List<EventResponse>> getEventsByStage(
+            @Parameter(description = "Tournament stage") @PathVariable Stage stage) {
         return ResponseEntity.ok(eventService.getEventsByStage(stage).stream().map(EventResponse::from).toList());
     }
 
+    @Operation(summary = "Get events by status")
     @GetMapping("/status/{status}")
-    public ResponseEntity<List<EventResponse>> getEventsByStatus(@PathVariable MatchStatus status) {
+    public ResponseEntity<List<EventResponse>> getEventsByStatus(
+            @Parameter(description = "Match status") @PathVariable MatchStatus status) {
         return ResponseEntity.ok(eventService.getEventsByStatus(status).stream().map(EventResponse::from).toList());
     }
 
+    @Operation(summary = "Get events by team")
+    @ApiResponse(responseCode = "404", description = "Team not found")
     @GetMapping("/team/{teamId}")
-    public ResponseEntity<List<EventResponse>> getEventsByTeam(@PathVariable Long teamId) {
+    public ResponseEntity<List<EventResponse>> getEventsByTeam(
+            @Parameter(description = "Team ID") @PathVariable Long teamId) {
         return ResponseEntity.ok(eventService.getEventsByTeam(teamService.getTeamById(teamId)).stream().map(EventResponse::from).toList());
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -3,6 +3,10 @@ package com.snodgrass.fifa_api.controller;
 import com.snodgrass.fifa_api.dto.TeamResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,21 +16,28 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/teams")
 @RequiredArgsConstructor
+@Tag(name = "Teams", description = "Endpoints for retrieving World Cup team data")
 public class TeamController {
     private final TeamService teamService;
 
+    @Operation(summary = "Get all teams")
     @GetMapping
     public ResponseEntity<List<TeamResponse>> getAllTeams() {
         return ResponseEntity.ok(teamService.getAllTeams().stream().map(TeamResponse::from).toList());
     }
 
+    @Operation(summary = "Get team by ID")
+    @ApiResponse(responseCode = "404", description = "Team not found")
     @GetMapping("/{id}")
-    public ResponseEntity<TeamResponse> getTeamById(@PathVariable Long id) {
+    public ResponseEntity<TeamResponse> getTeamById(
+            @Parameter(description = "Team ID") @PathVariable Long id) {
         return ResponseEntity.ok(TeamResponse.from(teamService.getTeamById(id)));
     }
 
+    @Operation(summary = "Get teams by group")
     @GetMapping("/group/{group}")
-    public ResponseEntity<List<TeamResponse>> getTeamsByGroup(@PathVariable Group group) {
+    public ResponseEntity<List<TeamResponse>> getTeamsByGroup(
+            @Parameter(description = "Group letter (A-L)") @PathVariable Group group) {
         return ResponseEntity.ok(teamService.getTeamsByGroup(group).stream().map(TeamResponse::from).toList());
     }
 }


### PR DESCRIPTION
- Added `springdoc-openapi-starter-webmvc-ui:3.0.2` dependency for API documentation                 
- Added `OpenApiConfig` to define API title, version, and description                                                                                                                                            
- Added OpenAPI annotations to `TeamController` & `EventController`                                                                                                                                              
    - `@Tag` for grouping endpoints in Swagger UI                                                                                                                                                                
    - `@Operation` for endpoint summaries                                                                                                                                                                        
    - `@Parameter` for path variable descriptions                                                                                                                                                                
    - `@ApiResponse` for 404 responses                                                                                                                                                                           
- Added `README.md` covering project purpose, tech stack, database setup, and all available endpoints  