### PR TITLE
Add Team Endpoint That Includes Squad

### DIFF
--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.TeamResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
@@ -29,13 +30,13 @@ public class TeamController {
         return ResponseEntity.ok(teamService.getAllTeams().stream().map(TeamResponse::from).toList());
     }
 
-    @Operation(summary = "Get team by ID")
+    @Operation(summary = "Get team details by ID (includes squad information")
     @ApiResponse(responseCode = "404", description = "Team not found")
     @GetMapping("/{id}")
-    public ResponseEntity<TeamResponse> getTeamById(
+    public ResponseEntity<TeamDetailResponse> getTeamById(
             @Parameter(description = "Team ID") @PathVariable Long id) {
         log.debug("GET /api/teams/{} - Fetching team by id", id);
-        return ResponseEntity.ok(TeamResponse.from(teamService.getTeamById(id)));
+        return ResponseEntity.ok(TeamDetailResponse.from(teamService.getTeamById(id)));
     }
 
     @Operation(summary = "Get teams by group")

--- a/src/main/java/com/snodgrass/fifa_api/dto/PlayerResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/PlayerResponse.java
@@ -1,0 +1,8 @@
+package com.snodgrass.fifa_api.dto;
+
+public record PlayerResponse (
+    String name,
+    Integer number,
+    String position,
+    Boolean isCaptain
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/dto/TeamDetailResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/TeamDetailResponse.java
@@ -1,0 +1,51 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.Group;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+public record TeamDetailResponse(
+        Long id,
+        String countryName,
+        String countryCode,
+        Group groupLetter,
+        String flagUrl,
+        String logoUrl,
+        Integer fifaRanking,
+        String managerName,
+        TeamStatsResponse stats,
+        List<PlayerResponse> squad
+) {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static TeamDetailResponse from(Team team) {
+        List<PlayerResponse> parsedSquad = List.of();
+
+        if (team.getSquad() != null && !team.getSquad().isBlank()) {
+            try {
+                parsedSquad = MAPPER.readValue(team.getSquad(), new TypeReference<>() {});
+            } catch (JsonProcessingException e) {
+                log.error("Failed to parse squad JSON for team ID {}", team.getId(), e);
+            }
+        }
+
+        return new TeamDetailResponse(
+                team.getId(),
+                team.getCountryName(),
+                team.getCountryCode(),
+                team.getGroupLetter(),
+                team.getFlagUrl(),
+                team.getLogoUrl(),
+                team.getFifaRanking(),
+                team.getManagerName(),
+                TeamStatsResponse.from(team.getStats()),
+                parsedSquad
+        );
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.TeamResponse;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
@@ -38,6 +39,7 @@ class TeamControllerTests {
         team.setCountryName("Brazil");
         team.setCountryCode("BRA");
         team.setGroupLetter(Group.A);
+        team.setSquad("[{\"name\":\"Neymar Jr\",\"number\":10,\"position\":\"FW\",\"isCaptain\":true}]");
         team.setCreatedAt(LocalDateTime.now());
         team.setUpdatedAt(LocalDateTime.now());
     }
@@ -67,12 +69,15 @@ class TeamControllerTests {
     void getTeamById_returns200_whenFound() {
         when(teamService.getTeamById(1L)).thenReturn(team);
 
-        ResponseEntity<TeamResponse> response = teamController.getTeamById(1L);
+        ResponseEntity<TeamDetailResponse> response = teamController.getTeamById(1L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assert response.getBody() != null;
         assertThat(response.getBody().id()).isEqualTo(1L);
         assertThat(response.getBody().countryName()).isEqualTo("Brazil");
+        assertThat(response.getBody().squad()).hasSize(1);
+        assertThat(response.getBody().squad().getFirst().name()).isEqualTo("Neymar Jr");
+        assertThat(response.getBody().squad().getFirst().isCaptain()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
- Added `PlayerResponse` dto that holds squad information
- Added `TeamDetailResponse` dto represents the `TeamResponse` but with squad information
    - Decided to keep using records, which cannot inherit, so some code duplication
- Updated `TeamController` to use the `TeamDetailResponse` when the get by id endpoint is used
- Updated tests
- close #8 