### PR TITLE
Add Testing DB and Add Multi-Tenancy to Support It

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A read-only REST API serving FIFA World Cup 2026 team and match (mock) data.
 
 ## Setup
 
-### 1. Database
+### 1. Database Setup
 
 The project includes a Python script that creates the database, tables, and seeds all data — 48 teams with full squads and 104 matches (72 group stage + 32 knockout). Match dates are generated dynamically starting from tomorrow relative to when the script is run.
 
@@ -111,3 +111,55 @@ http://localhost:8080/v3/api-docs
 **Stage values:** `GROUP`, `ROUND_OF_32`, `ROUND_OF_16`, `QUARTERFINAL`, `SEMIFINAL`, `THIRD_PLACE`, `FINAL`
 
 **Status values:** `SCHEDULED`, `IN_PROGRESS`, `HALFTIME`, `FINISHED`, `POSTPONED`, `CANCELLED`
+
+---
+
+## Multi-Tenancy
+
+The API uses Hibernate's multi-tenancy support to route database queries to different MySQL schemas depending on the request context. This allows the application and its tests to operate against separate databases without any code changes.
+
+### How It Works
+
+Two schemas are used:
+
+| Schema | Purpose |
+|--------|---------|
+| `fifa_world_cup` | Production schema, used for all normal requests |
+| `fifa_world_cup_test` | Test schema, used when the test header is present |
+
+On each request, a `HandlerInterceptor` reads an HTTP header and sets the active schema on a `ThreadLocal`. Hibernate's `CurrentTenantIdentifierResolver` reads that value to determine which schema to query, and `MultiTenantConnectionProvider` switches the JDBC connection to the correct MySQL catalog before executing any query. The `ThreadLocal` is cleared after each request completes.
+
+### Switching to the Test Schema
+
+To route a request to the test schema, include the following HTTP header:
+
+```
+X-DB-STATE: MODIFIED
+```
+
+Any request without this header, or with a different value, will use the production schema.
+
+Example using curl:
+
+```bash
+# Production schema (default)
+curl http://localhost:8080/api/teams
+
+# Test schema
+curl -H "X-DB-STATE: MODIFIED" http://localhost:8080/api/teams
+```
+
+### Configuration
+
+The schema names and header details are controlled by properties in `application.properties`:
+
+```properties
+app.tenant.default-schema=fifa_world_cup
+app.tenant.test-schema=fifa_world_cup_test
+app.tenant.http-test-header=X-DB-STATE
+app.tenant.http-test-header-value=MODIFIED
+```
+
+### Setup Script
+
+The Python setup script (`setup_worldcup.py`) creates and seeds both schemas. Run it once before starting the application or running integration tests.

--- a/src/main/java/com/snodgrass/fifa_api/config/HibernateConfig.java
+++ b/src/main/java/com/snodgrass/fifa_api/config/HibernateConfig.java
@@ -1,0 +1,26 @@
+package com.snodgrass.fifa_api.config;
+
+import com.snodgrass.fifa_api.tenant.TenantConnectionProvider;
+import com.snodgrass.fifa_api.tenant.TenantIdentifierResolver;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+public class HibernateConfig implements HibernatePropertiesCustomizer {
+    private final TenantConnectionProvider tenantConnectionProvider;
+    private final TenantIdentifierResolver tenantIdentifierResolver;
+
+    public HibernateConfig(TenantConnectionProvider tenantConnectionProvider, TenantIdentifierResolver tenantIndentifierResolver) {
+        this.tenantConnectionProvider = tenantConnectionProvider;
+        this.tenantIdentifierResolver = tenantIndentifierResolver;
+    }
+
+    @Override
+    public void customize(Map<String, Object> hibernateProperties) {
+        hibernateProperties.put(AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER, tenantConnectionProvider);
+        hibernateProperties.put(AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER, tenantIdentifierResolver);
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/config/WebConfig.java
+++ b/src/main/java/com/snodgrass/fifa_api/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.snodgrass.fifa_api.config;
+
+import com.snodgrass.fifa_api.tenant.TenantInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final TenantInterceptor tenantInterceptor;
+
+    public WebConfig(TenantInterceptor tenantInterceptor) {
+        this.tenantInterceptor = tenantInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(tenantInterceptor).addPathPatterns("/api/**");
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/tenant/TenantConnectionProvider.java
+++ b/src/main/java/com/snodgrass/fifa_api/tenant/TenantConnectionProvider.java
@@ -1,0 +1,73 @@
+package com.snodgrass.fifa_api.tenant;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@Slf4j
+@Component("tenantConnectionProvider")
+public class TenantConnectionProvider implements MultiTenantConnectionProvider<String> {
+    private final DataSource dataSource;
+
+    @Value("${app.tenant.default-schema}")
+    private String defaultSchema;
+
+    public TenantConnectionProvider(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Connection getAnyConnection() throws SQLException {
+        return getConnection(defaultSchema);
+    }
+
+    @Override
+    public void releaseAnyConnection(Connection connection) throws SQLException {
+        connection.close();
+    }
+
+    @Override
+    public Connection getConnection(String tenantIdentifier) throws SQLException {
+        Connection connection = dataSource.getConnection();
+        try {
+            if (tenantIdentifier != null) {
+                connection.setCatalog(tenantIdentifier);
+            }
+        } catch (SQLException e) {
+            connection.close(); // Prevent connection leak
+            throw new SQLException("Could not switch to schema: " + tenantIdentifier, e);
+        }
+        return connection;
+    }
+
+    @Override
+    public void releaseConnection(String tenantIdentifier, Connection connection) throws SQLException {
+        try {
+            connection.setCatalog(defaultSchema);
+        } catch (SQLException e) {
+            log.warn("Failed to reset connection to default schema before releasing: {}", e.getMessage());
+        } finally {
+            releaseAnyConnection(connection);
+        }
+    }
+
+    @Override
+    public boolean supportsAggressiveRelease() {
+        return false;
+    }
+
+    @Override
+    public boolean isUnwrappableAs(Class<?> unwrapType) {
+        return false;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> unwrapType) {
+        return null;
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/tenant/TenantContext.java
+++ b/src/main/java/com/snodgrass/fifa_api/tenant/TenantContext.java
@@ -1,0 +1,17 @@
+package com.snodgrass.fifa_api.tenant;
+
+public class TenantContext {
+    private static final ThreadLocal<String> CURRENT_TENANT = new ThreadLocal<>();
+
+    public static String getCurrentTenant() {
+        return CURRENT_TENANT.get();
+    }
+
+    public static void setCurrentTenant(String tenant) {
+        CURRENT_TENANT.set(tenant);
+    }
+
+    public static void clear() {
+        CURRENT_TENANT.remove();
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/tenant/TenantIdentifierResolver.java
+++ b/src/main/java/com/snodgrass/fifa_api/tenant/TenantIdentifierResolver.java
@@ -1,0 +1,22 @@
+package com.snodgrass.fifa_api.tenant;
+
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component(value = "tenantIdentifierResolver")
+public class TenantIdentifierResolver implements CurrentTenantIdentifierResolver<String> {
+    @Value("${app.tenant.default-schema}")
+    private String defaultSchema;
+
+    @Override
+    public String resolveCurrentTenantIdentifier() {
+        String tenant = TenantContext.getCurrentTenant();
+        return tenant != null ? tenant : defaultSchema;
+    }
+
+    @Override
+    public boolean validateExistingCurrentSessions() {
+        return true;
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/tenant/TenantInterceptor.java
+++ b/src/main/java/com/snodgrass/fifa_api/tenant/TenantInterceptor.java
@@ -1,0 +1,44 @@
+package com.snodgrass.fifa_api.tenant;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component("tenantInterceptor")
+public class TenantInterceptor implements HandlerInterceptor {
+    @Value("${app.tenant.default-schema}")
+    private String defaultSchema;
+
+    @Value("${app.tenant.test-schema}")
+    private String testSchema;
+
+    @Value("${app.tenant.http-test-header}")
+    private String httpTestHeader;
+
+    @Value("${app.tenant.http-test-header-value}")
+    private String httpTestHeaderValue;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
+        String tenant = request.getHeader(httpTestHeader);
+
+        if (httpTestHeaderValue.equalsIgnoreCase(tenant)) {
+            TenantContext.setCurrentTenant(testSchema);
+        } else {
+            TenantContext.setCurrentTenant(defaultSchema);
+        }
+
+        log.debug("Setting tenant context to: {}", TenantContext.getCurrentTenant());
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, Exception ex) {
+        TenantContext.clear();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,14 @@ spring.application.name=fifa-api
 logging.level.com.snodgrass.fifa_api=DEBUG
 
 # Database
-spring.datasource.url=jdbc:mysql://localhost:3306/fifa_world_cup
+spring.datasource.url=jdbc:mysql://localhost:3306/?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=utf-8
 spring.datasource.username=root
 spring.datasource.password=${DB_PASSWORD}
+
+# Schema names for prod and testing
+app.tenant.default-schema=fifa_world_cup
+app.tenant.test-schema=fifa_world_cup_test
+
+# Hibernate multi-tenancy config
+app.tenant.http-test-header=X-DB-STATE
+app.tenant.http-test-header-value=MODIFIED

--- a/src/main/resources/tools/setup_worldcup.py
+++ b/src/main/resources/tools/setup_worldcup.py
@@ -22,6 +22,7 @@ import getpass
 
 # ── Connection Config ────────────────────────────────────────
 DB_NAME = "fifa_world_cup"
+DB_TEST_NAME = "fifa_world_cup_test"
 MYSQL_HOST = "localhost"
 MYSQL_USER = "root"
 
@@ -31,79 +32,82 @@ MYSQL_USER = "root"
 TOURNAMENT_START = date.today() + timedelta(days=1)
 
 # ── DDL ──────────────────────────────────────────────────────
-DDL_STATEMENTS = [
-    f"DROP DATABASE IF EXISTS {DB_NAME}",
-    f"CREATE DATABASE {DB_NAME} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
-    f"USE {DB_NAME}",
-    "SET time_zone = '+00:00'",
-    """
-    CREATE TABLE teams (
-        id              INT UNSIGNED    NOT NULL AUTO_INCREMENT,
-        country_name    VARCHAR(100)    NOT NULL,
-        country_code    CHAR(3)         NOT NULL COMMENT 'FIFA country code',
-        flag_url        VARCHAR(512)    DEFAULT NULL,
-        logo_url        VARCHAR(512)    DEFAULT NULL,
-        fifa_ranking    SMALLINT UNSIGNED DEFAULT NULL,
-        group_letter    CHAR(1)         NOT NULL COMMENT 'Tournament group A-L',
-        manager_name    VARCHAR(200)    DEFAULT NULL,
-        squad           JSON            DEFAULT NULL,
-        matches_played  TINYINT UNSIGNED NOT NULL DEFAULT 0,
-        wins            TINYINT UNSIGNED NOT NULL DEFAULT 0,
-        draws           TINYINT UNSIGNED NOT NULL DEFAULT 0,
-        losses          TINYINT UNSIGNED NOT NULL DEFAULT 0,
-        goals_for       SMALLINT UNSIGNED NOT NULL DEFAULT 0,
-        goals_against   SMALLINT UNSIGNED NOT NULL DEFAULT 0,
-        goal_difference SMALLINT         NOT NULL DEFAULT 0,
-        group_points    TINYINT UNSIGNED NOT NULL DEFAULT 0,
-        yellow_cards    SMALLINT UNSIGNED NOT NULL DEFAULT 0,
-        red_cards       SMALLINT UNSIGNED NOT NULL DEFAULT 0,
-        eliminated      BOOLEAN         NOT NULL DEFAULT FALSE,
-        created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        PRIMARY KEY (id),
-        UNIQUE KEY uq_country_code (country_code),
-        UNIQUE KEY uq_country_name (country_name),
-        INDEX idx_group (group_letter)
-    ) ENGINE=InnoDB
-    """,
-    """
-    CREATE TABLE events (
-        id                    INT UNSIGNED    NOT NULL AUTO_INCREMENT,
-        match_number          SMALLINT UNSIGNED NOT NULL COMMENT 'Official match number 1-104',
-        stage                 ENUM('GROUP','ROUND_OF_32','ROUND_OF_16','QUARTERFINAL','SEMIFINAL','THIRD_PLACE','FINAL') NOT NULL,
-        group_letter          CHAR(1)         DEFAULT NULL,
-        home_team_id          INT UNSIGNED    DEFAULT NULL,
-        away_team_id          INT UNSIGNED    DEFAULT NULL,
-        home_team_placeholder VARCHAR(50)     DEFAULT NULL,
-        away_team_placeholder VARCHAR(50)     DEFAULT NULL,
-        match_date            DATE            NOT NULL,
-        kickoff_time          TIME            DEFAULT NULL,
-        kickoff_utc           DATETIME        DEFAULT NULL,
-        arena_name            VARCHAR(200)    NOT NULL,
-        city                  VARCHAR(100)    NOT NULL,
-        status                ENUM('SCHEDULED','IN_PROGRESS','HALFTIME','FINISHED','POSTPONED','CANCELLED') NOT NULL DEFAULT 'SCHEDULED',
-        match_state           JSON            DEFAULT NULL,
-        home_score            TINYINT UNSIGNED DEFAULT NULL,
-        away_score            TINYINT UNSIGNED DEFAULT NULL,
-        winner_team_id        INT UNSIGNED    DEFAULT NULL,
-        is_draw               BOOLEAN         DEFAULT NULL,
-        has_extra_time        BOOLEAN         NOT NULL DEFAULT FALSE,
-        has_penalties         BOOLEAN         NOT NULL DEFAULT FALSE,
-        created_at            TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at            TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        PRIMARY KEY (id),
-        UNIQUE KEY uq_match_number (match_number),
-        INDEX idx_stage (stage),
-        INDEX idx_match_date (match_date),
-        INDEX idx_status (status),
-        INDEX idx_home_team (home_team_id),
-        INDEX idx_away_team (away_team_id),
-        CONSTRAINT fk_home_team  FOREIGN KEY (home_team_id)  REFERENCES teams(id) ON DELETE SET NULL ON UPDATE CASCADE,
-        CONSTRAINT fk_away_team  FOREIGN KEY (away_team_id)  REFERENCES teams(id) ON DELETE SET NULL ON UPDATE CASCADE,
-        CONSTRAINT fk_winner     FOREIGN KEY (winner_team_id) REFERENCES teams(id) ON DELETE SET NULL ON UPDATE CASCADE
-    ) ENGINE=InnoDB
-    """,
-]
+def create_ddl_statement(db_name):
+    DDL_STATEMENTS = [
+        f"DROP DATABASE IF EXISTS {db_name}",
+        f"CREATE DATABASE {db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
+        f"USE {db_name}",
+        "SET time_zone = '+00:00'",
+        """
+        CREATE TABLE teams (
+            id              INT UNSIGNED    NOT NULL AUTO_INCREMENT,
+            country_name    VARCHAR(100)    NOT NULL,
+            country_code    CHAR(3)         NOT NULL COMMENT 'FIFA country code',
+            flag_url        VARCHAR(512)    DEFAULT NULL,
+            logo_url        VARCHAR(512)    DEFAULT NULL,
+            fifa_ranking    SMALLINT UNSIGNED DEFAULT NULL,
+            group_letter    CHAR(1)         NOT NULL COMMENT 'Tournament group A-L',
+            manager_name    VARCHAR(200)    DEFAULT NULL,
+            squad           JSON            DEFAULT NULL,
+            matches_played  TINYINT UNSIGNED NOT NULL DEFAULT 0,
+            wins            TINYINT UNSIGNED NOT NULL DEFAULT 0,
+            draws           TINYINT UNSIGNED NOT NULL DEFAULT 0,
+            losses          TINYINT UNSIGNED NOT NULL DEFAULT 0,
+            goals_for       SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            goals_against   SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            goal_difference SMALLINT         NOT NULL DEFAULT 0,
+            group_points    TINYINT UNSIGNED NOT NULL DEFAULT 0,
+            yellow_cards    SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            red_cards       SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+            eliminated      BOOLEAN         NOT NULL DEFAULT FALSE,
+            created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY uq_country_code (country_code),
+            UNIQUE KEY uq_country_name (country_name),
+            INDEX idx_group (group_letter)
+        ) ENGINE=InnoDB
+        """,
+        """
+        CREATE TABLE events (
+            id                    INT UNSIGNED    NOT NULL AUTO_INCREMENT,
+            match_number          SMALLINT UNSIGNED NOT NULL COMMENT 'Official match number 1-104',
+            stage                 ENUM('GROUP','ROUND_OF_32','ROUND_OF_16','QUARTERFINAL','SEMIFINAL','THIRD_PLACE','FINAL') NOT NULL,
+            group_letter          CHAR(1)         DEFAULT NULL,
+            home_team_id          INT UNSIGNED    DEFAULT NULL,
+            away_team_id          INT UNSIGNED    DEFAULT NULL,
+            home_team_placeholder VARCHAR(50)     DEFAULT NULL,
+            away_team_placeholder VARCHAR(50)     DEFAULT NULL,
+            match_date            DATE            NOT NULL,
+            kickoff_time          TIME            DEFAULT NULL,
+            kickoff_utc           DATETIME        DEFAULT NULL,
+            arena_name            VARCHAR(200)    NOT NULL,
+            city                  VARCHAR(100)    NOT NULL,
+            status                ENUM('SCHEDULED','IN_PROGRESS','HALFTIME','FINISHED','POSTPONED','CANCELLED') NOT NULL DEFAULT 'SCHEDULED',
+            match_state           JSON            DEFAULT NULL,
+            home_score            TINYINT UNSIGNED DEFAULT NULL,
+            away_score            TINYINT UNSIGNED DEFAULT NULL,
+            winner_team_id        INT UNSIGNED    DEFAULT NULL,
+            is_draw               BOOLEAN         DEFAULT NULL,
+            has_extra_time        BOOLEAN         NOT NULL DEFAULT FALSE,
+            has_penalties         BOOLEAN         NOT NULL DEFAULT FALSE,
+            created_at            TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at            TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY uq_match_number (match_number),
+            INDEX idx_stage (stage),
+            INDEX idx_match_date (match_date),
+            INDEX idx_status (status),
+            INDEX idx_home_team (home_team_id),
+            INDEX idx_away_team (away_team_id),
+            CONSTRAINT fk_home_team  FOREIGN KEY (home_team_id)  REFERENCES teams(id) ON DELETE SET NULL ON UPDATE CASCADE,
+            CONSTRAINT fk_away_team  FOREIGN KEY (away_team_id)  REFERENCES teams(id) ON DELETE SET NULL ON UPDATE CASCADE,
+            CONSTRAINT fk_winner     FOREIGN KEY (winner_team_id) REFERENCES teams(id) ON DELETE SET NULL ON UPDATE CASCADE
+        ) ENGINE=InnoDB
+        """,
+    ]
+
+    return DDL_STATEMENTS
 
 # ── Venues (actual 2026 host stadiums) ───────────────────────
 VENUES = [
@@ -883,41 +887,19 @@ def generate_knockout_matches(start_date, next_match_num, venues):
     return matches
 
 
-# ── Main ─────────────────────────────────────────────────────
-def main():
-    print("=" * 60)
-    print("  FIFA World Cup 2026 — Database Setup")
-    print("=" * 60)
-    print(f"  Tournament start date: {TOURNAMENT_START}")
-    print(f"  MySQL host: {MYSQL_HOST}")
-    print(f"  MySQL user: {MYSQL_USER}")
-    print()
-
-    password = getpass.getpass(f"Enter MySQL password for '{MYSQL_USER}': ")
-
-    try:
-        conn = mysql.connect(
-            host=MYSQL_HOST,
-            user=MYSQL_USER,
-            password=password,
-        )
-    except mysql.Error as e:
-        print(f"  [ERROR] Could not connect to MySQL: {e}")
-        sys.exit(1)
-
+# ── Per-database Setup ───────────────────────────────────────
+def setup_database(conn, db_name):
+    """Create, populate, and seed a single database by name."""
     cursor = conn.cursor()
-    print("\n  [1/4] Creating database and tables...")
+    print(f"\n  Setting up '{db_name}'...")
+    print("    [1/4] Creating database and tables...")
 
-    for stmt in DDL_STATEMENTS:
+    for stmt in create_ddl_statement(db_name):
         cursor.execute(stmt)
     conn.commit()
 
-    # Switch to the new database
-    cursor.execute(f"USE {DB_NAME}")
-    cursor.execute("SET time_zone = '+00:00'")
-
     # ── Insert teams ─────────────────────────────────────────
-    print("  [2/4] Inserting 48 teams with squads...")
+    print("    [2/4] Inserting 48 teams with squads...")
 
     team_insert = """
         INSERT INTO teams
@@ -939,18 +921,18 @@ def main():
         code_to_id[t_code] = cursor.lastrowid
 
     conn.commit()
-    print(f"         → {len(TEAMS_DATA)} teams inserted.")
+    print(f"           → {len(TEAMS_DATA)} teams inserted.")
 
     # ── Generate & insert matches ────────────────────────────
-    print("  [3/4] Generating match schedule...")
+    print("    [3/4] Generating match schedule...")
 
     group_matches, next_mn = generate_group_matches(TOURNAMENT_START, VENUES)
     knockout_matches = generate_knockout_matches(TOURNAMENT_START, next_mn, VENUES)
 
     all_matches = group_matches + knockout_matches
-    print(f"         → {len(group_matches)} group + {len(knockout_matches)} knockout = {len(all_matches)} total")
+    print(f"           → {len(group_matches)} group + {len(knockout_matches)} knockout = {len(all_matches)} total")
 
-    print("  [4/4] Inserting matches...")
+    print("    [4/4] Inserting matches...")
 
     event_insert = """
         INSERT INTO events
@@ -967,7 +949,6 @@ def main():
         away_id = code_to_id.get(m.get("away_code"))
 
         if home_id and away_id:
-            # Group match — look up team names for placeholders too
             h_name = next(t[0] for t in TEAMS_DATA if t[1] == m["home_code"])
             a_name = next(t[0] for t in TEAMS_DATA if t[1] == m["away_code"])
             h_placeholder = h_name
@@ -996,15 +977,43 @@ def main():
         ))
 
     conn.commit()
-    print(f"         → {len(all_matches)} matches inserted.")
+    print(f"           → {len(all_matches)} matches inserted.")
 
     cursor.close()
+    print(f"    ✓ '{db_name}' is ready.")
+
+
+# ── Main ─────────────────────────────────────────────────────
+def main():
+    print("=" * 60)
+    print("  FIFA World Cup 2026 — Database Setup")
+    print("=" * 60)
+    print(f"  Tournament start date: {TOURNAMENT_START}")
+    print(f"  MySQL host: {MYSQL_HOST}")
+    print(f"  MySQL user: {MYSQL_USER}")
+    print(f"  Databases: {DB_NAME}, {DB_TEST_NAME}")
+    print()
+
+    password = getpass.getpass(f"Enter MySQL password for '{MYSQL_USER}': ")
+
+    try:
+        conn = mysql.connect(
+            host=MYSQL_HOST,
+            user=MYSQL_USER,
+            password=password,
+        )
+    except mysql.Error as e:
+        print(f"  [ERROR] Could not connect to MySQL: {e}")
+        sys.exit(1)
+
+    for db_name in (DB_NAME, DB_TEST_NAME):
+        setup_database(conn, db_name)
+
     conn.close()
 
     print()
     print("=" * 60)
     print("  Setup complete!")
-    print(f"  Database '{DB_NAME}' is ready.")
     print(f"  First match: {TOURNAMENT_START}")
     print(f"  Final:       {TOURNAMENT_START + timedelta(days=31)}")
     print("=" * 60)

--- a/src/test/java/com/snodgrass/fifa_api/tenant/TenantConnectionProviderTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/tenant/TenantConnectionProviderTests.java
@@ -1,0 +1,92 @@
+package com.snodgrass.fifa_api.tenant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TenantConnectionProviderTests {
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private Connection connection;
+
+    @InjectMocks
+    private TenantConnectionProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(provider, "defaultSchema", "default_db");
+    }
+
+    @Test
+    void getAnyConnection_returnsConnectionFromDataSource() throws SQLException {
+        when(dataSource.getConnection()).thenReturn(connection);
+
+        Connection result = provider.getAnyConnection();
+
+        assertThat(result).isEqualTo(connection);
+        verify(dataSource).getConnection();
+        verify(connection).setCatalog("default_db");
+    }
+
+    @Test
+    void releaseAnyConnection_closesConnection() throws SQLException {
+        provider.releaseAnyConnection(connection);
+
+        verify(connection).close();
+    }
+
+    @Test
+    void getConnection_withTenant_setsCatalog() throws SQLException {
+        when(dataSource.getConnection()).thenReturn(connection);
+
+        Connection result = provider.getConnection("test_db");
+
+        assertThat(result).isEqualTo(connection);
+        verify(connection).setCatalog("test_db");
+    }
+
+    @Test
+    void getConnection_whenSetCatalogFails_closesConnectionAndThrows() throws SQLException {
+        when(dataSource.getConnection()).thenReturn(connection);
+        doThrow(new SQLException("Catalog error")).when(connection).setCatalog(anyString());
+
+        assertThatThrownBy(() -> provider.getConnection("invalid_db"))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("Could not switch to schema: invalid_db");
+
+        verify(connection).close();
+    }
+
+    @Test
+    void releaseConnection_resetsCatalogAndCloses() throws SQLException {
+        provider.releaseConnection("test_db", connection);
+
+        verify(connection).setCatalog("default_db");
+        verify(connection).close();
+    }
+
+    @Test
+    void releaseConnection_whenSetCatalogFails_stillClosesConnection() throws SQLException {
+        doThrow(new SQLException("Catalog error")).when(connection).setCatalog(anyString());
+
+        provider.releaseConnection("test_db", connection);
+
+        verify(connection).close(); // Ensure releaseAnyConnection is still called via finally
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/tenant/TenantContextTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/tenant/TenantContextTests.java
@@ -1,0 +1,33 @@
+package com.snodgrass.fifa_api.tenant;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TenantContextTests {
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void setCurrentTenant_setsTenant() {
+        TenantContext.setCurrentTenant("my_tenant");
+
+        assertThat(TenantContext.getCurrentTenant()).isEqualTo("my_tenant");
+    }
+
+    @Test
+    void clear_removesTenant() {
+        TenantContext.setCurrentTenant("my_tenant");
+        TenantContext.clear();
+
+        assertThat(TenantContext.getCurrentTenant()).isNull();
+    }
+    
+    @Test
+    void getCurrentTenant_returnsNullInitially() {
+        assertThat(TenantContext.getCurrentTenant()).isNull();
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/tenant/TenantIdentifierResolverTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/tenant/TenantIdentifierResolverTests.java
@@ -1,0 +1,45 @@
+package com.snodgrass.fifa_api.tenant;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TenantIdentifierResolverTests {
+    private TenantIdentifierResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new TenantIdentifierResolver();
+        ReflectionTestUtils.setField(resolver, "defaultSchema", "default_db");
+        TenantContext.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void resolveCurrentTenantIdentifier_withContextSet_returnsTenant() {
+        TenantContext.setCurrentTenant("test_db");
+
+        String tenant = resolver.resolveCurrentTenantIdentifier();
+
+        assertThat(tenant).isEqualTo("test_db");
+    }
+
+    @Test
+    void resolveCurrentTenantIdentifier_withNoContext_returnsDefaultSchema() {
+        String tenant = resolver.resolveCurrentTenantIdentifier();
+
+        assertThat(tenant).isEqualTo("default_db");
+    }
+
+    @Test
+    void validateExistingCurrentSessions_returnsTrue() {
+        assertThat(resolver.validateExistingCurrentSessions()).isTrue();
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/tenant/TenantInterceptorTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/tenant/TenantInterceptorTests.java
@@ -1,0 +1,94 @@
+package com.snodgrass.fifa_api.tenant;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TenantInterceptorTests {
+
+    @InjectMocks
+    private TenantInterceptor tenantInterceptor;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private Object handler;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(tenantInterceptor, "defaultSchema", "default_db");
+        ReflectionTestUtils.setField(tenantInterceptor, "testSchema", "test_db");
+        ReflectionTestUtils.setField(tenantInterceptor, "httpTestHeader", "X-DB-STATE");
+        ReflectionTestUtils.setField(tenantInterceptor, "httpTestHeaderValue", "MODIFIED");
+        TenantContext.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void preHandle_withValidHeader_setsTestSchema() {
+        when(request.getHeader("X-DB-STATE")).thenReturn("MODIFIED");
+
+        boolean result = tenantInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        assertThat(TenantContext.getCurrentTenant()).isEqualTo("test_db");
+    }
+
+    @Test
+    void preHandle_withInvalidHeader_setsDefaultSchema() {
+        when(request.getHeader("X-DB-STATE")).thenReturn("OTHER");
+
+        boolean result = tenantInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        assertThat(TenantContext.getCurrentTenant()).isEqualTo("default_db");
+    }
+
+    @Test
+    void preHandle_withoutHeader_setsDefaultSchema() {
+        when(request.getHeader("X-DB-STATE")).thenReturn(null);
+
+        boolean result = tenantInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        assertThat(TenantContext.getCurrentTenant()).isEqualTo("default_db");
+    }
+
+    @Test
+    void preHandle_withDifferentCaseHeaderValue_setsTestSchema() {
+        when(request.getHeader("X-DB-STATE")).thenReturn("modified");
+
+        boolean result = tenantInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        assertThat(TenantContext.getCurrentTenant()).isEqualTo("test_db");
+    }
+
+    @Test
+    void afterCompletion_clearsContext() {
+        TenantContext.setCurrentTenant("some_tenant");
+
+        tenantInterceptor.afterCompletion(request, response, handler, null);
+
+        assertThat(TenantContext.getCurrentTenant()).isNull();
+    }
+}


### PR DESCRIPTION
- Added multi-tenancy support using Hibernate's `MultiTenantConnectionProvider` and `CurrentTenantIdentifierResolver` to route queries to different MySQL schemas per request
- Added a ThreadLocal-based `TenantContext` to hold the active schema for the duration of a request
- Added `TenantInterceptor` to read an HTTP header on each request and set the tenant context accordingly, cleared after the request completes
- Added `WebConfig` to register the interceptor against `/api/**` routes
- Added `HibernateConfig` to wire the tenant beans into Hibernate directly — the beans are passed as object instances rather than class name strings so Hibernate doesn't try to instantiate
them itself
- Updated `application.properties` with the schema names and header config, removed the broken string-based Hibernate properties that were replaced by HibernateConfig
- Updated the Python setup script to create and seed both the prod and test schemas
- Added tests for all four tenant classes
- Updated `README` with multi-tenancy documentation
- closes #10 