### PR TITLE
Create CUD Endpoints for Teams (Test DB Only)

### DIFF
--- a/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
@@ -1,6 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.dto.EventResponse;
+import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,15 +1,19 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.request.TeamRequest;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,5 +49,54 @@ public class TeamController {
             @Parameter(description = "Group letter (A-L)") @PathVariable Group group) {
         log.debug("GET /api/teams/group/{} - Fetching teams by group", group);
         return ResponseEntity.ok(teamService.getTeamsByGroup(group).stream().map(TeamResponse::from).toList());
+    }
+
+    @Operation(summary = "Create a new team (test database only)",
+            description = "Requires the X-DB-STATE: MODIFIED header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = "X-DB-STATE", in = ParameterIn.HEADER, required = true,
+                    description = "Must be 'MODIFIED' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "201", description = "Team created successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid X-DB-STATE header")
+    @PostMapping
+    public ResponseEntity<TeamDetailResponse> createTeam(@Valid @RequestBody TeamRequest teamRequest) {
+        log.debug("POST /api/teams - Creating team");
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(TeamDetailResponse.from(teamService.createTeam(teamRequest)));
+    }
+
+    @Operation(summary = "Update an existing team (test database only)",
+            description = "Requires the X-DB-STATE: MODIFIED header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = "X-DB-STATE", in = ParameterIn.HEADER, required = true,
+                    description = "Must be 'MODIFIED' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "200", description = "Team updated successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid X-DB-STATE header")
+    @ApiResponse(responseCode = "404", description = "Team not found")
+    @PutMapping("/{id}")
+    public ResponseEntity<TeamDetailResponse> updateTeam(
+            @Parameter(description = "Team ID") @PathVariable Long id,
+            @Valid @RequestBody TeamRequest teamRequest) {
+        log.debug("PUT /api/teams/{} - Updating team", id);
+        return ResponseEntity.ok(TeamDetailResponse.from(teamService.updateTeam(id, teamRequest)));
+    }
+
+    @Operation(summary = "Delete a team (test database only)",
+            description = "Requires the X-DB-STATE: MODIFIED header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = "X-DB-STATE", in = ParameterIn.HEADER, required = true,
+                    description = "Must be 'MODIFIED' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "204", description = "Team deleted successfully")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid X-DB-STATE header")
+    @ApiResponse(responseCode = "404", description = "Team not found")
+    @ApiResponse(responseCode = "409", description = "Team has associated events")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTeam(
+            @Parameter(description = "Team ID") @PathVariable Long id) {
+        log.debug("DELETE /api/teams/{} - Deleting team", id);
+        teamService.deleteTeam(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,7 +1,7 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.dto.TeamDetailResponse;
-import com.snodgrass.fifa_api.dto.TeamResponse;
+import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
+import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/PlayerRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/PlayerRequest.java
@@ -17,12 +17,12 @@ public record PlayerRequest(
 
         Boolean isCaptain
 ) {
-        public static PlayerRequest from(TeamPlayer player) {
-              return new PlayerRequest(
-                      player.getName(),
-                      player.getNumber(),
-                      player.getPosition(),
-                      player.getIsCaptain()
-              );
-        }
+    public TeamPlayer toEntity() {
+        return new TeamPlayer(
+                this.name,
+                this.number,
+                this.position,
+                this.isCaptain
+        );
+    }
 }

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/PlayerRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/PlayerRequest.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.dto.request;
 
+import com.snodgrass.fifa_api.model.TeamPlayer;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Min;
@@ -15,4 +16,13 @@ public record PlayerRequest(
         String position,
 
         Boolean isCaptain
-) {}
+) {
+        public static PlayerRequest from(TeamPlayer player) {
+              return new PlayerRequest(
+                      player.getName(),
+                      player.getNumber(),
+                      player.getPosition(),
+                      player.getIsCaptain()
+              );
+        }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/PlayerRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/PlayerRequest.java
@@ -1,0 +1,18 @@
+package com.snodgrass.fifa_api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+
+public record PlayerRequest(
+        @NotBlank
+        String name,
+
+        @NotNull @Min(1)
+        Integer number,
+
+        @NotBlank
+        String position,
+
+        Boolean isCaptain
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/TeamRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/TeamRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record TeamRequest(
@@ -36,17 +37,20 @@ public record TeamRequest(
         @Valid
         TeamStatsRequest stats
 ) {
-        public static TeamRequest from(Team team) {
-              return new TeamRequest(
-                      team.getCountryName(),
-                      team.getCountryCode(),
-                      team.getGroupLetter(),
-                      team.getFlagUrl(),
-                      team.getLogoUrl(),
-                      team.getFifaRanking(),
-                      team.getManagerName(),
-                      team.getSquad() == null ? List.of() : team.getSquad().stream().map(PlayerRequest::from).toList(),
-                      TeamStatsRequest.from(team.getStats())
-              );
+        public Team toEntity() {
+                Team team = new Team();
+                team.setCountryName(this.countryName);
+                team.setCountryCode(this.countryCode);
+                team.setGroupLetter(this.groupLetter);
+                team.setFlagUrl(this.flagUrl);
+                team.setLogoUrl(this.logoUrl);
+                team.setFifaRanking(this.fifaRanking);
+                team.setManagerName(this.managerName);
+                team.setSquad(this.squad.stream().map(PlayerRequest::toEntity).toList());
+                team.setStats(this.stats.toEntity());
+                team.setCreatedAt(LocalDateTime.now());
+                team.setUpdatedAt(LocalDateTime.now());
+
+                return team;
         }
 }

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/TeamRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/TeamRequest.java
@@ -1,0 +1,37 @@
+package com.snodgrass.fifa_api.dto.request;
+
+import com.snodgrass.fifa_api.model.enums.Group;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record TeamRequest(
+        @NotBlank @Size(max = 100)
+        String countryName,
+
+        @NotBlank @Size(min = 3, max = 3)
+        String countryCode,
+
+        @NotNull
+        Group groupLetter,
+
+        String flagUrl,
+
+        String logoUrl,
+
+        @Min(1)
+        Integer fifaRanking,
+
+        @Size(max = 100)
+        String managerName,
+
+        @Valid
+        List<PlayerRequest> squad,
+
+        @Valid
+        TeamStatsRequest stats
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/TeamRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/TeamRequest.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.dto.request;
 
+import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -34,4 +35,18 @@ public record TeamRequest(
 
         @Valid
         TeamStatsRequest stats
-) {}
+) {
+        public static TeamRequest from(Team team) {
+              return new TeamRequest(
+                      team.getCountryName(),
+                      team.getCountryCode(),
+                      team.getGroupLetter(),
+                      team.getFlagUrl(),
+                      team.getLogoUrl(),
+                      team.getFifaRanking(),
+                      team.getManagerName(),
+                      team.getSquad() == null ? List.of() : team.getSquad().stream().map(PlayerRequest::from).toList(),
+                      TeamStatsRequest.from(team.getStats())
+              );
+        }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/TeamStatsRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/TeamStatsRequest.java
@@ -16,19 +16,21 @@ public record TeamStatsRequest(
         @Min(0) int redCards,
         boolean eliminated
 ) {
-    public static TeamStatsRequest from(TeamStats teamStats) {
-        return new TeamStatsRequest(
-                teamStats.getMatchesPlayed(),
-                teamStats.getWins(),
-                teamStats.getDraws(),
-                teamStats.getLosses(),
-                teamStats.getGoalsFor(),
-                teamStats.getGoalsAgainst(),
-                teamStats.getGoalDifference(),
-                teamStats.getGroupPoints(),
-                teamStats.getYellowCards(),
-                teamStats.getRedCards(),
-                teamStats.isEliminated()
-        );
+    public TeamStats toEntity() {
+        TeamStats stats = new TeamStats();
+
+        stats.setMatchesPlayed(this.matchesPlayed);
+        stats.setWins(this.wins);
+        stats.setDraws(this.draws);
+        stats.setLosses(this.losses);
+        stats.setGoalsFor(this.goalsFor);
+        stats.setGoalsAgainst(this.goalsAgainst);
+        stats.setGoalDifference(this.goalDifference);
+        stats.setGroupPoints(this.groupPoints);
+        stats.setYellowCards(this.yellowCards);
+        stats.setRedCards(this.redCards);
+        stats.setEliminated(this.eliminated);
+
+        return stats;
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/TeamStatsRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/TeamStatsRequest.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.dto.request;
 
+import com.snodgrass.fifa_api.model.TeamStats;
 import jakarta.validation.constraints.Min;
 
 public record TeamStatsRequest(
@@ -14,4 +15,20 @@ public record TeamStatsRequest(
         @Min(0) int yellowCards,
         @Min(0) int redCards,
         boolean eliminated
-) {}
+) {
+    public static TeamStatsRequest from(TeamStats teamStats) {
+        return new TeamStatsRequest(
+                teamStats.getMatchesPlayed(),
+                teamStats.getWins(),
+                teamStats.getDraws(),
+                teamStats.getLosses(),
+                teamStats.getGoalsFor(),
+                teamStats.getGoalsAgainst(),
+                teamStats.getGoalDifference(),
+                teamStats.getGroupPoints(),
+                teamStats.getYellowCards(),
+                teamStats.getRedCards(),
+                teamStats.isEliminated()
+        );
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/TeamStatsRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/TeamStatsRequest.java
@@ -1,0 +1,17 @@
+package com.snodgrass.fifa_api.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record TeamStatsRequest(
+        @Min(0) int matchesPlayed,
+        @Min(0) int wins,
+        @Min(0) int draws,
+        @Min(0) int losses,
+        @Min(0) int goalsFor,
+        @Min(0) int goalsAgainst,
+        int goalDifference,
+        @Min(0) int groupPoints,
+        @Min(0) int yellowCards,
+        @Min(0) int redCards,
+        boolean eliminated
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/EventResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/EventResponse.java
@@ -1,4 +1,4 @@
-package com.snodgrass.fifa_api.dto;
+package com.snodgrass.fifa_api.dto.response;
 
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.enums.Group;

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/PlayerResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/PlayerResponse.java
@@ -1,8 +1,19 @@
 package com.snodgrass.fifa_api.dto.response;
 
+import com.snodgrass.fifa_api.model.TeamPlayer;
+
 public record PlayerResponse (
     String name,
     Integer number,
     String position,
     Boolean isCaptain
-) {}
+) {
+    public static PlayerResponse from(TeamPlayer player) {
+        return new PlayerResponse(
+                player.getName(),
+                player.getNumber(),
+                player.getPosition(),
+                player.getIsCaptain()
+        );
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/PlayerResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/PlayerResponse.java
@@ -1,4 +1,4 @@
-package com.snodgrass.fifa_api.dto;
+package com.snodgrass.fifa_api.dto.response;
 
 public record PlayerResponse (
     String name,

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/TeamDetailResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/TeamDetailResponse.java
@@ -1,4 +1,4 @@
-package com.snodgrass.fifa_api.dto;
+package com.snodgrass.fifa_api.dto.response;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/TeamDetailResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/TeamDetailResponse.java
@@ -1,15 +1,10 @@
 package com.snodgrass.fifa_api.dto.response;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
-@Slf4j
 public record TeamDetailResponse(
         Long id,
         String countryName,
@@ -22,18 +17,10 @@ public record TeamDetailResponse(
         TeamStatsResponse stats,
         List<PlayerResponse> squad
 ) {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     public static TeamDetailResponse from(Team team) {
-        List<PlayerResponse> parsedSquad = List.of();
-
-        if (team.getSquad() != null && !team.getSquad().isBlank()) {
-            try {
-                parsedSquad = MAPPER.readValue(team.getSquad(), new TypeReference<>() {});
-            } catch (JsonProcessingException e) {
-                log.error("Failed to parse squad JSON for team ID {}", team.getId(), e);
-            }
-        }
+        List<PlayerResponse> parsedSquad = team.getSquad() == null
+                ? List.of()
+                : team.getSquad().stream().map(PlayerResponse::from).toList();
 
         return new TeamDetailResponse(
                 team.getId(),

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/TeamResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/TeamResponse.java
@@ -1,4 +1,4 @@
-package com.snodgrass.fifa_api.dto;
+package com.snodgrass.fifa_api.dto.response;
 
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/TeamStatsResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/TeamStatsResponse.java
@@ -1,4 +1,4 @@
-package com.snodgrass.fifa_api.dto;
+package com.snodgrass.fifa_api.dto.response;
 
 import com.snodgrass.fifa_api.model.TeamStats;
 

--- a/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.snodgrass.fifa_api.exception;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,6 +16,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(404, ex.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(TeamHasEventsException.class)
+    public ResponseEntity<ErrorResponse> handleTeamHasEvents(TeamHasEventsException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(409, ex.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, ex.getMessage(), LocalDateTime.now()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/snodgrass/fifa_api/exception/TeamHasEventsException.java
+++ b/src/main/java/com/snodgrass/fifa_api/exception/TeamHasEventsException.java
@@ -1,0 +1,7 @@
+package com.snodgrass.fifa_api.exception;
+
+public class TeamHasEventsException extends RuntimeException {
+    public TeamHasEventsException(Long teamId) {
+        super("Cannot delete team with id: " + teamId + " because it has associated events.");
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/model/Team.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/Team.java
@@ -1,11 +1,13 @@
 package com.snodgrass.fifa_api.model;
 
+import com.snodgrass.fifa_api.model.converter.TeamPlayerListConverter;
 import com.snodgrass.fifa_api.model.enums.Group;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "teams")
@@ -27,7 +29,8 @@ public class Team {
     private Group groupLetter;
 
     @Column(name = "squad", columnDefinition = "JSON")
-    private String squad;
+    @Convert(converter = TeamPlayerListConverter.class)
+    private List<TeamPlayer> squad;
 
     @Embedded
     private TeamStats stats;

--- a/src/main/java/com/snodgrass/fifa_api/model/TeamPlayer.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/TeamPlayer.java
@@ -1,0 +1,17 @@
+package com.snodgrass.fifa_api.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamPlayer {
+    private String name;
+    private Integer number;
+    private String position;
+    private Boolean isCaptain;
+}

--- a/src/main/java/com/snodgrass/fifa_api/model/converter/TeamPlayerListConverter.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/converter/TeamPlayerListConverter.java
@@ -1,0 +1,44 @@
+package com.snodgrass.fifa_api.model.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snodgrass.fifa_api.model.TeamPlayer;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Converter
+public class TeamPlayerListConverter implements AttributeConverter<List<TeamPlayer>, String> {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<TeamPlayer> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize squad to JSON", e);
+            return null;
+        }
+    }
+
+    @Override
+    public List<TeamPlayer> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return MAPPER.readValue(dbData, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize squad JSON", e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
+++ b/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
@@ -14,4 +14,5 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByStage(Stage stage);
     List<Event> findByStatus(MatchStatus status);
     List<Event> findByHomeTeamOrAwayTeam(Team homeTeam, Team awayTeam);
+    boolean existsByHomeTeamOrAwayTeam(Team homeTeam, Team awayTeam);
 }

--- a/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
@@ -1,6 +1,7 @@
 package com.snodgrass.fifa_api.service;
 
 import com.snodgrass.fifa_api.dto.request.TeamRequest;
+import com.snodgrass.fifa_api.exception.TeamHasEventsException;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.repository.EventRepository;
@@ -28,5 +29,22 @@ public class TeamService {
 
     public List<Team> getTeamsByGroup(Group group) {
         return teamRepository.findByGroupLetter(group);
+    }
+
+    public Team createTeam(TeamRequest teamRequest) {
+        return teamRepository.save(teamRequest.toEntity());
+    }
+
+    public Team updateTeam(Long id, TeamRequest dto) {
+        teamRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("Team not found with id: " + id));
+        return teamRepository.save(dto.toEntity());
+    }
+
+    public void deleteTeam(Long id) {
+        Team team = teamRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("Team not found with id: " + id));
+        if (eventRepository.existsByHomeTeamOrAwayTeam(team, team)) {
+            throw new TeamHasEventsException(id);
+        }
+        teamRepository.delete(team);
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/TeamService.java
@@ -1,7 +1,9 @@
 package com.snodgrass.fifa_api.service;
 
+import com.snodgrass.fifa_api.dto.request.TeamRequest;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.repository.EventRepository;
 import com.snodgrass.fifa_api.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TeamService {
     private final TeamRepository teamRepository;
+    private final EventRepository eventRepository;
 
     public List<Team> getAllTeams() {
         return teamRepository.findAll();

--- a/src/main/java/com/snodgrass/fifa_api/tenant/TenantInterceptor.java
+++ b/src/main/java/com/snodgrass/fifa_api/tenant/TenantInterceptor.java
@@ -1,12 +1,20 @@
 package com.snodgrass.fifa_api.tenant;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.snodgrass.fifa_api.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Set;
 
 @Slf4j
 @Component("tenantInterceptor")
@@ -23,14 +31,35 @@ public class TenantInterceptor implements HandlerInterceptor {
     @Value("${app.tenant.http-test-header-value}")
     private String httpTestHeaderValue;
 
-    @Override
-    public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
-        String tenant = request.getHeader(httpTestHeader);
+    private static final Set<String> MUTATING_METHODS = Set.of("POST", "PUT", "PATCH", "DELETE");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
 
-        if (httpTestHeaderValue.equalsIgnoreCase(tenant)) {
+    @Override
+    public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) throws IOException {
+        String tenant = request.getHeader(httpTestHeader);
+        boolean isTestContext = httpTestHeaderValue.equalsIgnoreCase(tenant);
+
+        if (isTestContext) {
             TenantContext.setCurrentTenant(testSchema);
         } else {
             TenantContext.setCurrentTenant(defaultSchema);
+        }
+
+        // CUD Http Methods are only to be used on the test database
+        if (MUTATING_METHODS.contains(request.getMethod()) && !isTestContext) {
+            log.warn("Blocked {} request to {} — missing or invalid {} header", request.getMethod(), request.getRequestURI(), httpTestHeader);
+
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+            ErrorResponse errorResponse = new ErrorResponse(
+                    HttpServletResponse.SC_FORBIDDEN,
+                    "Write operations require the " + httpTestHeader + ": " + httpTestHeaderValue + " header",
+                    LocalDateTime.now()
+            );
+            OBJECT_MAPPER.writeValue(response.getWriter(), errorResponse);
+
+            return false;
         }
 
         log.debug("Setting tenant context to: {}", TenantContext.getCurrentTenant());

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -1,6 +1,7 @@
 package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.dto.response.EventResponse;
+import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.exception.ErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,10 +10,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,5 +79,135 @@ class ControllerIntegrationTests {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().message()).contains("999999");
+    }
+
+    // Team CUD
+
+    private String teamJson(String countryName, String countryCode) {
+        return """
+                {
+                    "countryName": "%s",
+                    "countryCode": "%s",
+                    "groupLetter": "A",
+                    "fifaRanking": 50,
+                    "squad": [{"name": "Test Player", "number": 10, "position": "FW", "isCaptain": true}],
+                    "stats": {"matchesPlayed": 0, "wins": 0, "draws": 0, "losses": 0, "goalsFor": 0, "goalsAgainst": 0, "goalDifference": 0, "groupPoints": 0, "yellowCards": 0, "redCards": 0, "eliminated": false}
+                }
+                """.formatted(countryName, countryCode);
+    }
+
+    private String randomCode() {
+        return UUID.randomUUID().toString().substring(0, 3).toUpperCase();
+    }
+
+    @Test
+    void createTeam_returns201() {
+        String code = randomCode();
+        String name = "Create Test " + code;
+        String json = teamJson(name, code);
+
+        ResponseEntity<TeamDetailResponse> response = restClient.post()
+                .uri("/api/teams")
+                .header("X-DB-STATE", "MODIFIED")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(json)
+                .retrieve()
+                .toEntity(TeamDetailResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().countryName()).isEqualTo(name);
+        assertThat(response.getBody().squad()).hasSize(1);
+    }
+
+    @Test
+    void updateTeam_returns200() {
+        // First create a team with unique data
+        String createCode = randomCode();
+        String createName = "Update Pre " + createCode;
+        ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
+                .uri("/api/teams")
+                .header("X-DB-STATE", "MODIFIED")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(teamJson(createName, createCode))
+                .retrieve()
+                .toEntity(TeamDetailResponse.class);
+
+        Long teamId = createResponse.getBody().id();
+
+        String updateCode = randomCode();
+        String updateName = "Update Post " + updateCode;
+        ResponseEntity<TeamDetailResponse> response = restClient.put()
+                .uri("/api/teams/" + teamId)
+                .header("X-DB-STATE", "MODIFIED")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(teamJson(updateName, updateCode))
+                .retrieve()
+                .toEntity(TeamDetailResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().countryName()).isEqualTo(updateName);
+        assertThat(response.getBody().countryCode()).isEqualTo(updateCode);
+    }
+
+    @Test
+    void deleteTeam_returns204() {
+        // First create a team with unique data to delete
+        String delCode = randomCode();
+        ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
+                .uri("/api/teams")
+                .header("X-DB-STATE", "MODIFIED")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(teamJson("Delete Test " + delCode, delCode))
+                .retrieve()
+                .toEntity(TeamDetailResponse.class);
+
+        Long teamId = createResponse.getBody().id();
+
+        ResponseEntity<Void> response = restClient.delete()
+                .uri("/api/teams/" + teamId)
+                .header("X-DB-STATE", "MODIFIED")
+                .retrieve()
+                .toBodilessEntity();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    void createTeam_withoutTestHeader_returns403() {
+        ResponseEntity<String> response = restClient.post()
+                .uri("/api/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(teamJson("Forbidden Country", randomCode()))
+                .retrieve()
+                .onStatus(status -> status.value() == 403, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void updateTeam_withoutTestHeader_returns403() {
+        ResponseEntity<String> response = restClient.put()
+                .uri("/api/teams/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(teamJson("Forbidden Update", randomCode()))
+                .retrieve()
+                .onStatus(status -> status.value() == 403, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void deleteTeam_withoutTestHeader_returns403() {
+        ResponseEntity<String> response = restClient.delete()
+                .uri("/api/teams/1")
+                .retrieve()
+                .onStatus(status -> status.value() == 403, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -1,7 +1,7 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.dto.EventResponse;
-import com.snodgrass.fifa_api.dto.TeamResponse;
+import com.snodgrass.fifa_api.dto.response.EventResponse;
+import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.exception.ErrorResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
@@ -1,6 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.dto.EventResponse;
+import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -1,7 +1,11 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.request.PlayerRequest;
+import com.snodgrass.fifa_api.dto.request.TeamRequest;
+import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
+import com.snodgrass.fifa_api.exception.TeamHasEventsException;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.TeamPlayer;
 import com.snodgrass.fifa_api.model.enums.Group;
@@ -21,7 +25,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
 
 @ExtendWith(MockitoExtension.class)
 class TeamControllerTests {
@@ -109,5 +116,92 @@ class TeamControllerTests {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEmpty();
+    }
+
+    // CUD helpers
+
+    private TeamRequest validTeamRequest() {
+        List<PlayerRequest> squad = List.of(
+                new PlayerRequest("Neymar Jr", 10, "FW", true)
+        );
+        TeamStatsRequest stats = new TeamStatsRequest(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
+        return new TeamRequest("Brazil", "BRA", Group.A,
+                "/flags/bra.png", "/logos/bra.png", 1, "Dorival Júnior", squad, stats);
+    }
+
+    // createTeam
+
+    @Test
+    void createTeam_returns201WithBody() {
+        TeamRequest request = validTeamRequest();
+        when(teamService.createTeam(any(TeamRequest.class))).thenReturn(team);
+
+        ResponseEntity<TeamDetailResponse> response = teamController.createTeam(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().countryName()).isEqualTo("Brazil");
+        verify(teamService, times(1)).createTeam(any(TeamRequest.class));
+    }
+
+    // updateTeam
+
+    @Test
+    void updateTeam_returns200WithBody() {
+        TeamRequest request = validTeamRequest();
+        when(teamService.updateTeam(eq(1L), any(TeamRequest.class))).thenReturn(team);
+
+        ResponseEntity<TeamDetailResponse> response = teamController.updateTeam(1L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().countryName()).isEqualTo("Brazil");
+        verify(teamService, times(1)).updateTeam(eq(1L), any(TeamRequest.class));
+    }
+
+    @Test
+    void updateTeam_throwsEntityNotFoundException_whenNotFound() {
+        TeamRequest request = validTeamRequest();
+        when(teamService.updateTeam(eq(99L), any(TeamRequest.class)))
+                .thenThrow(new EntityNotFoundException("Team not found with id: 99"));
+
+        assertThatThrownBy(() -> teamController.updateTeam(99L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // deleteTeam
+
+    @Test
+    void deleteTeam_returns204() {
+        doNothing().when(teamService).deleteTeam(1L);
+
+        ResponseEntity<Void> response = teamController.deleteTeam(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+        verify(teamService, times(1)).deleteTeam(1L);
+    }
+
+    @Test
+    void deleteTeam_throwsEntityNotFoundException_whenNotFound() {
+        doThrow(new EntityNotFoundException("Team not found with id: 99"))
+                .when(teamService).deleteTeam(99L);
+
+        assertThatThrownBy(() -> teamController.deleteTeam(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void deleteTeam_throwsTeamHasEventsException_whenTeamHasEvents() {
+        doThrow(new TeamHasEventsException(1L))
+                .when(teamService).deleteTeam(1L);
+
+        assertThatThrownBy(() -> teamController.deleteTeam(1L))
+                .isInstanceOf(TeamHasEventsException.class)
+                .hasMessageContaining("1");
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -3,6 +3,7 @@ package com.snodgrass.fifa_api.controller;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.TeamPlayer;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
 import jakarta.persistence.EntityNotFoundException;
@@ -39,7 +40,7 @@ class TeamControllerTests {
         team.setCountryName("Brazil");
         team.setCountryCode("BRA");
         team.setGroupLetter(Group.A);
-        team.setSquad("[{\"name\":\"Neymar Jr\",\"number\":10,\"position\":\"FW\",\"isCaptain\":true}]");
+        team.setSquad(List.of(new TeamPlayer("Neymar Jr", 10, "FW", true)));
         team.setCreatedAt(LocalDateTime.now());
         team.setUpdatedAt(LocalDateTime.now());
     }

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -1,7 +1,7 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.dto.TeamDetailResponse;
-import com.snodgrass.fifa_api.dto.TeamResponse;
+import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
+import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;

--- a/src/test/java/com/snodgrass/fifa_api/dto/PlayerRequestTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/PlayerRequestTests.java
@@ -1,6 +1,7 @@
 package com.snodgrass.fifa_api.dto;
 
 import com.snodgrass.fifa_api.dto.request.PlayerRequest;
+import com.snodgrass.fifa_api.model.TeamPlayer;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -94,5 +95,29 @@ class PlayerRequestTests {
         PlayerRequest player = new PlayerRequest("Neymar Jr", 10, "", true);
         Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
         assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("position"));
+    }
+
+    // toEntity
+
+    @Test
+    void toEntity_mapsAllFields() {
+        PlayerRequest request = new PlayerRequest("Neymar Jr", 10, "FW", true);
+
+        TeamPlayer entity = request.toEntity();
+
+        assertThat(entity.getName()).isEqualTo("Neymar Jr");
+        assertThat(entity.getNumber()).isEqualTo(10);
+        assertThat(entity.getPosition()).isEqualTo("FW");
+        assertThat(entity.getIsCaptain()).isTrue();
+    }
+
+    @Test
+    void toEntity_withNullIsCaptain_mapsNullCaptain() {
+        PlayerRequest request = new PlayerRequest("Alisson", 1, "GK", null);
+
+        TeamPlayer entity = request.toEntity();
+
+        assertThat(entity.getName()).isEqualTo("Alisson");
+        assertThat(entity.getIsCaptain()).isNull();
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/dto/PlayerRequestTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/PlayerRequestTests.java
@@ -1,0 +1,98 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.dto.request.PlayerRequest;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlayerRequestTests {
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private PlayerRequest validPlayer() {
+        return new PlayerRequest("Neymar Jr", 10, "FW", true);
+    }
+
+    @Test
+    void validPlayerRequest_hasNoViolations() {
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(validPlayer());
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void validPlayerRequest_withNullIsCaptain_hasNoViolations() {
+        PlayerRequest player = new PlayerRequest("Neymar Jr", 10, "FW", null);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).isEmpty();
+    }
+
+    // name
+    @Test
+    void nullName_hasViolation() {
+        PlayerRequest player = new PlayerRequest(null, 10, "FW", true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("name"));
+    }
+
+    @Test
+    void blankName_hasViolation() {
+        PlayerRequest player = new PlayerRequest("", 10, "FW", true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("name"));
+    }
+
+    @Test
+    void whitespaceName_hasViolation() {
+        PlayerRequest player = new PlayerRequest("   ", 10, "FW", true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("name"));
+    }
+
+    // number
+    @Test
+    void nullNumber_hasViolation() {
+        PlayerRequest player = new PlayerRequest("Neymar Jr", null, "FW", true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("number"));
+    }
+
+    @Test
+    void zeroNumber_hasViolation() {
+        PlayerRequest player = new PlayerRequest("Neymar Jr", 0, "FW", true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("number"));
+    }
+
+    @Test
+    void negativeNumber_hasViolation() {
+        PlayerRequest player = new PlayerRequest("Neymar Jr", -1, "FW", true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("number"));
+    }
+
+    // position
+    @Test
+    void nullPosition_hasViolation() {
+        PlayerRequest player = new PlayerRequest("Neymar Jr", 10, null, true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("position"));
+    }
+
+    @Test
+    void blankPosition_hasViolation() {
+        PlayerRequest player = new PlayerRequest("Neymar Jr", 10, "", true);
+        Set<ConstraintViolation<PlayerRequest>> violations = validator.validate(player);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("position"));
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/dto/ResponseDtoMappingTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/ResponseDtoMappingTests.java
@@ -1,0 +1,251 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.dto.response.*;
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.TeamPlayer;
+import com.snodgrass.fifa_api.model.TeamStats;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResponseDtoMappingTests {
+
+    private Team team;
+    private TeamStats stats;
+
+    @BeforeEach
+    void setUp() {
+        stats = new TeamStats();
+        stats.setMatchesPlayed(3);
+        stats.setWins(2);
+        stats.setDraws(1);
+        stats.setLosses(0);
+        stats.setGoalsFor(5);
+        stats.setGoalsAgainst(2);
+        stats.setGoalDifference(3);
+        stats.setGroupPoints(7);
+        stats.setYellowCards(3);
+        stats.setRedCards(1);
+        stats.setEliminated(false);
+
+        team = new Team();
+        team.setId(1L);
+        team.setCountryName("Brazil");
+        team.setCountryCode("BRA");
+        team.setGroupLetter(Group.A);
+        team.setFlagUrl("/flags/bra.png");
+        team.setLogoUrl("/logos/bra.png");
+        team.setFifaRanking(1);
+        team.setManagerName("Dorival Júnior");
+        team.setStats(stats);
+        team.setSquad(List.of(new TeamPlayer("Neymar Jr", 10, "FW", true)));
+        team.setCreatedAt(LocalDateTime.now());
+        team.setUpdatedAt(LocalDateTime.now());
+    }
+
+    // PlayerResponse.from()
+
+    @Test
+    void playerResponse_from_mapsAllFields() {
+        TeamPlayer player = new TeamPlayer("Neymar Jr", 10, "FW", true);
+
+        PlayerResponse response = PlayerResponse.from(player);
+
+        assertThat(response.name()).isEqualTo("Neymar Jr");
+        assertThat(response.number()).isEqualTo(10);
+        assertThat(response.position()).isEqualTo("FW");
+        assertThat(response.isCaptain()).isTrue();
+    }
+
+    @Test
+    void playerResponse_from_withNullCaptain() {
+        TeamPlayer player = new TeamPlayer("Alisson", 1, "GK", null);
+
+        PlayerResponse response = PlayerResponse.from(player);
+
+        assertThat(response.isCaptain()).isNull();
+    }
+
+    // TeamStatsResponse.from()
+
+    @Test
+    void teamStatsResponse_from_mapsAllFields() {
+        TeamStatsResponse response = TeamStatsResponse.from(stats);
+
+        assertThat(response.matchesPlayed()).isEqualTo(3);
+        assertThat(response.wins()).isEqualTo(2);
+        assertThat(response.draws()).isEqualTo(1);
+        assertThat(response.losses()).isEqualTo(0);
+        assertThat(response.goalsFor()).isEqualTo(5);
+        assertThat(response.goalsAgainst()).isEqualTo(2);
+        assertThat(response.goalDifference()).isEqualTo(3);
+        assertThat(response.groupPoints()).isEqualTo(7);
+        assertThat(response.yellowCards()).isEqualTo(3);
+        assertThat(response.redCards()).isEqualTo(1);
+        assertThat(response.eliminated()).isFalse();
+    }
+
+    @Test
+    void teamStatsResponse_from_withNull_returnsNull() {
+        TeamStatsResponse response = TeamStatsResponse.from(null);
+        assertThat(response).isNull();
+    }
+
+    // TeamResponse.from()
+
+    @Test
+    void teamResponse_from_mapsAllFields() {
+        TeamResponse response = TeamResponse.from(team);
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.countryName()).isEqualTo("Brazil");
+        assertThat(response.countryCode()).isEqualTo("BRA");
+        assertThat(response.groupLetter()).isEqualTo(Group.A);
+        assertThat(response.flagUrl()).isEqualTo("/flags/bra.png");
+        assertThat(response.logoUrl()).isEqualTo("/logos/bra.png");
+        assertThat(response.fifaRanking()).isEqualTo(1);
+        assertThat(response.managerName()).isEqualTo("Dorival Júnior");
+        assertThat(response.stats()).isNotNull();
+        assertThat(response.stats().wins()).isEqualTo(2);
+    }
+
+    @Test
+    void teamResponse_from_withNullStats() {
+        team.setStats(null);
+
+        TeamResponse response = TeamResponse.from(team);
+
+        assertThat(response.stats()).isNull();
+    }
+
+    // TeamDetailResponse.from()
+
+    @Test
+    void teamDetailResponse_from_mapsAllFieldsIncludingSquad() {
+        TeamDetailResponse response = TeamDetailResponse.from(team);
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.countryName()).isEqualTo("Brazil");
+        assertThat(response.squad()).hasSize(1);
+        assertThat(response.squad().get(0).name()).isEqualTo("Neymar Jr");
+        assertThat(response.squad().get(0).isCaptain()).isTrue();
+        assertThat(response.stats()).isNotNull();
+    }
+
+    @Test
+    void teamDetailResponse_from_withNullSquad_returnsEmptyList() {
+        team.setSquad(null);
+
+        TeamDetailResponse response = TeamDetailResponse.from(team);
+
+        assertThat(response.squad()).isEmpty();
+    }
+
+    @Test
+    void teamDetailResponse_from_withEmptySquad_returnsEmptyList() {
+        team.setSquad(List.of());
+
+        TeamDetailResponse response = TeamDetailResponse.from(team);
+
+        assertThat(response.squad()).isEmpty();
+    }
+
+    // EventResponse.from()
+
+    private Event createEvent() {
+        Event event = new Event();
+        event.setId(1L);
+        event.setMatchNumber(1);
+        event.setStage(Stage.GROUP);
+        event.setGroupLetter(Group.A);
+        event.setHomeTeam(team);
+
+        Team awayTeam = new Team();
+        awayTeam.setId(2L);
+        awayTeam.setCountryName("Argentina");
+        awayTeam.setCountryCode("ARG");
+        awayTeam.setGroupLetter(Group.A);
+        awayTeam.setCreatedAt(LocalDateTime.now());
+        awayTeam.setUpdatedAt(LocalDateTime.now());
+        event.setAwayTeam(awayTeam);
+
+        event.setMatchDate(LocalDate.of(2026, 6, 11));
+        event.setKickoffTime(LocalTime.of(20, 0));
+        event.setKickoffUtc(LocalDateTime.of(2026, 6, 11, 20, 0));
+        event.setArenaName("Lusail Stadium");
+        event.setCity("Lusail");
+        event.setStatus(MatchStatus.SCHEDULED);
+        event.setHomeScore(null);
+        event.setAwayScore(null);
+        event.setWinnerTeam(null);
+        event.setIsDraw(null);
+        event.setHasExtraTime(false);
+        event.setHasPenalties(false);
+        event.setCreatedAt(LocalDateTime.now());
+        event.setUpdatedAt(LocalDateTime.now());
+        return event;
+    }
+
+    @Test
+    void eventResponse_from_mapsAllFields() {
+        Event event = createEvent();
+
+        EventResponse response = EventResponse.from(event);
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.matchNumber()).isEqualTo(1);
+        assertThat(response.stage()).isEqualTo(Stage.GROUP);
+        assertThat(response.groupLetter()).isEqualTo(Group.A);
+        assertThat(response.homeTeam()).isNotNull();
+        assertThat(response.homeTeam().countryName()).isEqualTo("Brazil");
+        assertThat(response.awayTeam()).isNotNull();
+        assertThat(response.awayTeam().countryName()).isEqualTo("Argentina");
+        assertThat(response.arenaName()).isEqualTo("Lusail Stadium");
+        assertThat(response.city()).isEqualTo("Lusail");
+        assertThat(response.status()).isEqualTo(MatchStatus.SCHEDULED);
+        assertThat(response.winnerTeam()).isNull();
+        assertThat(response.isDraw()).isNull();
+        assertThat(response.hasExtraTime()).isFalse();
+        assertThat(response.hasPenalties()).isFalse();
+    }
+
+    @Test
+    void eventResponse_from_withNullTeams_returnsNullTeamResponses() {
+        Event event = createEvent();
+        event.setHomeTeam(null);
+        event.setAwayTeam(null);
+
+        EventResponse response = EventResponse.from(event);
+
+        assertThat(response.homeTeam()).isNull();
+        assertThat(response.awayTeam()).isNull();
+    }
+
+    @Test
+    void eventResponse_from_withWinnerTeam_mapsWinner() {
+        Event event = createEvent();
+        event.setWinnerTeam(team);
+        event.setHomeScore(2);
+        event.setAwayScore(0);
+        event.setIsDraw(false);
+        event.setStatus(MatchStatus.FINISHED);
+
+        EventResponse response = EventResponse.from(event);
+
+        assertThat(response.winnerTeam()).isNotNull();
+        assertThat(response.winnerTeam().countryName()).isEqualTo("Brazil");
+        assertThat(response.homeScore()).isEqualTo(2);
+        assertThat(response.awayScore()).isEqualTo(0);
+        assertThat(response.isDraw()).isFalse();
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/dto/TeamRequestTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/TeamRequestTests.java
@@ -1,0 +1,153 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.dto.request.PlayerRequest;
+import com.snodgrass.fifa_api.dto.request.TeamRequest;
+import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
+
+import com.snodgrass.fifa_api.model.enums.Group;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TeamRequestTests {
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private TeamRequest validRequest() {
+        return new TeamRequest("Brazil", "BRA", Group.A,
+                "/flags/bra.png", "/logos/bra.png", 1, "Dorival Júnior",
+                null, null);
+    }
+
+    @Test
+    void validRequest_hasNoViolations() {
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(validRequest());
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void validRequest_withAllOptionalsNull_hasNoViolations() {
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    // countryName
+    @Test
+    void nullCountryName_hasViolation() {
+        TeamRequest request = new TeamRequest(null, "BRA", Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("countryName"));
+    }
+
+    @Test
+    void blankCountryName_hasViolation() {
+        TeamRequest request = new TeamRequest("", "BRA", Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("countryName"));
+    }
+
+    @Test
+    void countryNameTooLong_hasViolation() {
+        TeamRequest request = new TeamRequest("A".repeat(101), "BRA", Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("countryName"));
+    }
+
+    // countryCode
+    @Test
+    void nullCountryCode_hasViolation() {
+        TeamRequest request = new TeamRequest("Brazil", null, Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("countryCode"));
+    }
+
+    @Test
+    void countryCodeTooShort_hasViolation() {
+        TeamRequest request = new TeamRequest("Brazil", "BR", Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("countryCode"));
+    }
+
+    @Test
+    void countryCodeTooLong_hasViolation() {
+        TeamRequest request = new TeamRequest("Brazil", "BRAZ", Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("countryCode"));
+    }
+
+    // groupLetter
+    @Test
+    void nullGroupLetter_hasViolation() {
+        TeamRequest request = new TeamRequest("Brazil", "BRA", null,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("groupLetter"));
+    }
+
+    // fifaRanking
+    @Test
+    void fifaRankingZero_hasViolation() {
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                null, null, 0, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("fifaRanking"));
+    }
+
+    @Test
+    void fifaRankingNull_hasNoViolations() {
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                null, null, null, null, null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    // managerName
+    @Test
+    void managerNameTooLong_hasViolation() {
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                null, null, null, "A".repeat(101), null, null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("managerName"));
+    }
+
+    // Cascading @Valid on squad
+    @Test
+    void invalidPlayerInSquad_hasViolation() {
+        PlayerRequest invalidPlayer = new PlayerRequest("", 10, "FW", true);
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                null, null, null, null, List.of(invalidPlayer), null);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().contains("squad"));
+    }
+
+    // Cascading @Valid on stats
+    @Test
+    void invalidStats_hasViolation() {
+        TeamStatsRequest invalidStats = new TeamStatsRequest(-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                null, null, null, null, null, invalidStats);
+        Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().contains("stats"));
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/dto/TeamRequestTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/TeamRequestTests.java
@@ -4,6 +4,7 @@ import com.snodgrass.fifa_api.dto.request.PlayerRequest;
 import com.snodgrass.fifa_api.dto.request.TeamRequest;
 import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
 
+import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -149,5 +150,46 @@ class TeamRequestTests {
         Set<ConstraintViolation<TeamRequest>> violations = validator.validate(request);
         assertThat(violations).isNotEmpty();
         assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().contains("stats"));
+    }
+
+    // toEntity
+
+    @Test
+    void toEntity_mapsAllFields() {
+        List<PlayerRequest> squad = List.of(
+                new PlayerRequest("Neymar Jr", 10, "FW", true)
+        );
+        TeamStatsRequest stats = new TeamStatsRequest(3, 2, 1, 0, 5, 2, 3, 7, 3, 1, false);
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                "/flags/bra.png", "/logos/bra.png", 1, "Dorival Júnior", squad, stats);
+
+        Team entity = request.toEntity();
+
+        assertThat(entity.getCountryName()).isEqualTo("Brazil");
+        assertThat(entity.getCountryCode()).isEqualTo("BRA");
+        assertThat(entity.getGroupLetter()).isEqualTo(Group.A);
+        assertThat(entity.getFlagUrl()).isEqualTo("/flags/bra.png");
+        assertThat(entity.getLogoUrl()).isEqualTo("/logos/bra.png");
+        assertThat(entity.getFifaRanking()).isEqualTo(1);
+        assertThat(entity.getManagerName()).isEqualTo("Dorival Júnior");
+        assertThat(entity.getSquad()).hasSize(1);
+        assertThat(entity.getSquad().get(0).getName()).isEqualTo("Neymar Jr");
+        assertThat(entity.getStats()).isNotNull();
+        assertThat(entity.getStats().getWins()).isEqualTo(2);
+        assertThat(entity.getCreatedAt()).isNotNull();
+        assertThat(entity.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void toEntity_setsTimestamps() {
+        TeamRequest request = new TeamRequest("Brazil", "BRA", Group.A,
+                null, null, null, null,
+                List.of(new PlayerRequest("Neymar Jr", 10, "FW", true)),
+                new TeamStatsRequest(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false));
+
+        Team entity = request.toEntity();
+
+        assertThat(entity.getCreatedAt()).isNotNull();
+        assertThat(entity.getUpdatedAt()).isNotNull();
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/dto/TeamStatsRequestTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/TeamStatsRequestTests.java
@@ -1,6 +1,7 @@
 package com.snodgrass.fifa_api.dto;
 
 import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
+import com.snodgrass.fifa_api.model.TeamStats;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -69,5 +70,36 @@ class TeamStatsRequestTests {
         Set<ConstraintViolation<TeamStatsRequest>> violations = validator.validate(stats);
         assertThat(violations)
                 .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName));
+    }
+
+    // toEntity
+
+    @Test
+    void toEntity_mapsAllFields() {
+        TeamStatsRequest request = new TeamStatsRequest(3, 2, 1, 0, 5, 2, 3, 7, 3, 1, false);
+
+        TeamStats entity = request.toEntity();
+
+        assertThat(entity.getMatchesPlayed()).isEqualTo(3);
+        assertThat(entity.getWins()).isEqualTo(2);
+        assertThat(entity.getDraws()).isEqualTo(1);
+        assertThat(entity.getLosses()).isEqualTo(0);
+        assertThat(entity.getGoalsFor()).isEqualTo(5);
+        assertThat(entity.getGoalsAgainst()).isEqualTo(2);
+        assertThat(entity.getGoalDifference()).isEqualTo(3);
+        assertThat(entity.getGroupPoints()).isEqualTo(7);
+        assertThat(entity.getYellowCards()).isEqualTo(3);
+        assertThat(entity.getRedCards()).isEqualTo(1);
+        assertThat(entity.isEliminated()).isFalse();
+    }
+
+    @Test
+    void toEntity_withEliminated_mapsCorrectly() {
+        TeamStatsRequest request = new TeamStatsRequest(3, 0, 0, 3, 1, 5, -4, 0, 0, 0, true);
+
+        TeamStats entity = request.toEntity();
+
+        assertThat(entity.isEliminated()).isTrue();
+        assertThat(entity.getGoalDifference()).isEqualTo(-4);
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/dto/TeamStatsRequestTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/TeamStatsRequestTests.java
@@ -1,0 +1,73 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TeamStatsRequestTests {
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private TeamStatsRequest validStats() {
+        return new TeamStatsRequest(3, 2, 1, 0, 5, 2, 3, 7, 3, 0, false);
+    }
+
+    @Test
+    void validStats_hasNoViolations() {
+        Set<ConstraintViolation<TeamStatsRequest>> violations = validator.validate(validStats());
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void allZeros_hasNoViolations() {
+        TeamStatsRequest stats = new TeamStatsRequest(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
+        Set<ConstraintViolation<TeamStatsRequest>> violations = validator.validate(stats);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void negativeGoalDifference_hasNoViolations() {
+        TeamStatsRequest stats = new TeamStatsRequest(3, 0, 0, 3, 1, 5, -4, 0, 0, 0, false);
+        Set<ConstraintViolation<TeamStatsRequest>> violations = validator.validate(stats);
+        assertThat(violations).isEmpty();
+    }
+
+    // @Min(0) fields
+    @ParameterizedTest(name = "negative {0} has violation")
+    @ValueSource(strings = {"matchesPlayed", "wins", "draws", "losses", "goalsFor",
+            "goalsAgainst", "groupPoints", "yellowCards", "redCards"})
+    void negativeMinZeroField_hasViolation(String fieldName) {
+        // Build a stats object with the target field set to -1
+        TeamStatsRequest stats = new TeamStatsRequest(
+                fieldName.equals("matchesPlayed") ? -1 : 0,
+                fieldName.equals("wins") ? -1 : 0,
+                fieldName.equals("draws") ? -1 : 0,
+                fieldName.equals("losses") ? -1 : 0,
+                fieldName.equals("goalsFor") ? -1 : 0,
+                fieldName.equals("goalsAgainst") ? -1 : 0,
+                0, // goalDifference — no @Min
+                fieldName.equals("groupPoints") ? -1 : 0,
+                fieldName.equals("yellowCards") ? -1 : 0,
+                fieldName.equals("redCards") ? -1 : 0,
+                false
+        );
+
+        Set<ConstraintViolation<TeamStatsRequest>> violations = validator.validate(stats);
+        assertThat(violations)
+                .anyMatch(v -> v.getPropertyPath().toString().equals(fieldName));
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandlerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandlerTests.java
@@ -1,0 +1,80 @@
+package com.snodgrass.fifa_api.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTests {
+
+    private GlobalExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GlobalExceptionHandler();
+    }
+
+    @Test
+    void handleEntityNotFound_returns404WithMessage() {
+        EntityNotFoundException ex = new EntityNotFoundException("Team not found with id: 99");
+
+        ResponseEntity<ErrorResponse> response = handler.handleEntityNotFound(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(404);
+        assertThat(response.getBody().message()).isEqualTo("Team not found with id: 99");
+        assertThat(response.getBody().timestamp()).isNotNull();
+    }
+
+    @Test
+    void handleTeamHasEvents_returns409WithMessage() {
+        TeamHasEventsException ex = new TeamHasEventsException(1L);
+
+        ResponseEntity<ErrorResponse> response = handler.handleTeamHasEvents(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(409);
+        assertThat(response.getBody().message()).contains("1");
+        assertThat(response.getBody().timestamp()).isNotNull();
+    }
+
+    @Test
+    void handleValidationExceptions_returns400() throws NoSuchMethodException {
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "teamRequest");
+        bindingResult.addError(new FieldError("teamRequest", "countryName", "must not be blank"));
+
+        MethodParameter methodParameter = new MethodParameter(
+                GlobalExceptionHandlerTests.class.getDeclaredMethod("setUp"), -1);
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        ResponseEntity<ErrorResponse> response = handler.handleValidationExceptions(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().message()).isNotBlank();
+        assertThat(response.getBody().timestamp()).isNotNull();
+    }
+
+    @Test
+    void handleGeneric_returns500WithGenericMessage() {
+        Exception ex = new RuntimeException("Something unexpected");
+
+        ResponseEntity<ErrorResponse> response = handler.handleGeneric(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo(500);
+        assertThat(response.getBody().message()).isEqualTo("An unexpected error occurred");
+        assertThat(response.getBody().timestamp()).isNotNull();
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/model/converter/TeamPlayerListConverterTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/model/converter/TeamPlayerListConverterTests.java
@@ -1,0 +1,128 @@
+package com.snodgrass.fifa_api.model.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snodgrass.fifa_api.model.TeamPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TeamPlayerListConverterTests {
+
+    private TeamPlayerListConverter converter;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        converter = new TeamPlayerListConverter();
+    }
+
+    // convertToDatabaseColumn
+
+    @Test
+    void convertToDatabaseColumn_withValidList_returnsJsonString() throws JsonProcessingException {
+        List<TeamPlayer> players = List.of(
+                new TeamPlayer("Neymar Jr", 10, "FW", true),
+                new TeamPlayer("Alisson", 1, "GK", false)
+        );
+
+        String json = converter.convertToDatabaseColumn(players);
+
+        assertThat(json).isNotNull();
+        List<TeamPlayer> parsed = MAPPER.readValue(json, new TypeReference<>() {});
+        assertThat(parsed).hasSize(2);
+        assertThat(parsed.get(0).getName()).isEqualTo("Neymar Jr");
+        assertThat(parsed.get(0).getNumber()).isEqualTo(10);
+        assertThat(parsed.get(0).getPosition()).isEqualTo("FW");
+        assertThat(parsed.get(0).getIsCaptain()).isTrue();
+        assertThat(parsed.get(1).getName()).isEqualTo("Alisson");
+    }
+
+    @Test
+    void convertToDatabaseColumn_withNullList_returnsNull() {
+        String result = converter.convertToDatabaseColumn(null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void convertToDatabaseColumn_withEmptyList_returnsNull() {
+        String result = converter.convertToDatabaseColumn(Collections.emptyList());
+        assertThat(result).isNull();
+    }
+
+    // convertToEntityAttribute
+
+    @Test
+    void convertToEntityAttribute_withValidJson_returnsList() {
+        String json = "[{\"name\":\"Neymar Jr\",\"number\":10,\"position\":\"FW\",\"isCaptain\":true}]";
+
+        List<TeamPlayer> result = converter.convertToEntityAttribute(json);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Neymar Jr");
+        assertThat(result.get(0).getNumber()).isEqualTo(10);
+        assertThat(result.get(0).getPosition()).isEqualTo("FW");
+        assertThat(result.get(0).getIsCaptain()).isTrue();
+    }
+
+    @Test
+    void convertToEntityAttribute_withMultiplePlayers_returnsFullList() {
+        String json = "[{\"name\":\"Neymar Jr\",\"number\":10,\"position\":\"FW\",\"isCaptain\":true}," +
+                "{\"name\":\"Alisson\",\"number\":1,\"position\":\"GK\",\"isCaptain\":false}]";
+
+        List<TeamPlayer> result = converter.convertToEntityAttribute(json);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(1).getName()).isEqualTo("Alisson");
+        assertThat(result.get(1).getIsCaptain()).isFalse();
+    }
+
+    @Test
+    void convertToEntityAttribute_withNullString_returnsEmptyList() {
+        List<TeamPlayer> result = converter.convertToEntityAttribute(null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void convertToEntityAttribute_withBlankString_returnsEmptyList() {
+        List<TeamPlayer> result = converter.convertToEntityAttribute("   ");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void convertToEntityAttribute_withEmptyString_returnsEmptyList() {
+        List<TeamPlayer> result = converter.convertToEntityAttribute("");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void convertToEntityAttribute_withMalformedJson_returnsEmptyList() {
+        List<TeamPlayer> result = converter.convertToEntityAttribute("{not valid json");
+        assertThat(result).isEmpty();
+    }
+
+    // Round-trip
+
+    @Test
+    void roundTrip_serializeAndDeserialize_preservesData() {
+        List<TeamPlayer> original = List.of(
+                new TeamPlayer("Neymar Jr", 10, "FW", true),
+                new TeamPlayer("Alisson", 1, "GK", false)
+        );
+
+        String json = converter.convertToDatabaseColumn(original);
+        List<TeamPlayer> result = converter.convertToEntityAttribute(json);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo(original.get(0).getName());
+        assertThat(result.get(0).getNumber()).isEqualTo(original.get(0).getNumber());
+        assertThat(result.get(0).getPosition()).isEqualTo(original.get(0).getPosition());
+        assertThat(result.get(0).getIsCaptain()).isEqualTo(original.get(0).getIsCaptain());
+        assertThat(result.get(1).getName()).isEqualTo(original.get(1).getName());
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/repository/EventRepositoryTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/repository/EventRepositoryTests.java
@@ -59,4 +59,19 @@ public class EventRepositoryTests {
                 e.getAwayTeam().getId().equals(team.getId())
         );
     }
+
+    @Test
+    void existsByHomeTeamOrAwayTeam_returnsTrue_whenTeamHasEvents() {
+        Team team = teamRepository.findAll().getFirst();
+        boolean exists = eventRepository.existsByHomeTeamOrAwayTeam(team, team);
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void existsByHomeTeamOrAwayTeam_returnsFalse_whenTeamHasNoEvents() {
+        Team team = new Team();
+        team.setId(999999L);
+        boolean exists = eventRepository.existsByHomeTeamOrAwayTeam(team, team);
+        assertThat(exists).isFalse();
+    }
 }

--- a/src/test/java/com/snodgrass/fifa_api/service/TeamServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/TeamServiceTests.java
@@ -1,7 +1,12 @@
 package com.snodgrass.fifa_api.service;
 
+import com.snodgrass.fifa_api.dto.request.PlayerRequest;
+import com.snodgrass.fifa_api.dto.request.TeamRequest;
+import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
+import com.snodgrass.fifa_api.exception.TeamHasEventsException;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.repository.EventRepository;
 import com.snodgrass.fifa_api.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +22,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +30,9 @@ class TeamServiceTests {
 
     @Mock
     private TeamRepository teamRepository;
+
+    @Mock
+    private EventRepository eventRepository;
 
     @InjectMocks
     private TeamService teamService;
@@ -97,5 +106,101 @@ class TeamServiceTests {
         List<Team> result = teamService.getTeamsByGroup(Group.B);
 
         assertThat(result).isEmpty();
+    }
+
+    // createTeam
+
+    private TeamRequest validTeamRequest() {
+        List<PlayerRequest> squad = List.of(
+                new PlayerRequest("Neymar Jr", 10, "FW", true)
+        );
+        TeamStatsRequest stats = new TeamStatsRequest(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
+        return new TeamRequest("Brazil", "BRA", Group.A,
+                "/flags/bra.png", "/logos/bra.png", 1, "Dorival Júnior", squad, stats);
+    }
+
+    @Test
+    void createTeam_savesAndReturnsTeam() {
+        TeamRequest request = validTeamRequest();
+        when(teamRepository.save(any(Team.class))).thenAnswer(invocation -> {
+            Team saved = invocation.getArgument(0);
+            saved.setId(1L);
+            return saved;
+        });
+
+        Team result = teamService.createTeam(request);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getCountryName()).isEqualTo("Brazil");
+        assertThat(result.getCountryCode()).isEqualTo("BRA");
+        assertThat(result.getGroupLetter()).isEqualTo(Group.A);
+        verify(teamRepository, times(1)).save(any(Team.class));
+    }
+
+    // updateTeam
+
+    @Test
+    void updateTeam_savesAndReturnsUpdatedTeam() {
+        TeamRequest request = validTeamRequest();
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(team));
+        when(teamRepository.save(any(Team.class))).thenAnswer(invocation -> {
+            Team saved = invocation.getArgument(0);
+            saved.setId(1L);
+            return saved;
+        });
+
+        Team result = teamService.updateTeam(1L, request);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getCountryName()).isEqualTo("Brazil");
+        verify(teamRepository, times(1)).findById(1L);
+        verify(teamRepository, times(1)).save(any(Team.class));
+    }
+
+    @Test
+    void updateTeam_throwsEntityNotFoundException_whenNotFound() {
+        TeamRequest request = validTeamRequest();
+        when(teamRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> teamService.updateTeam(99L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+
+        verify(teamRepository, never()).save(any(Team.class));
+    }
+
+    // deleteTeam
+
+    @Test
+    void deleteTeam_deletesTeam_whenNoAssociatedEvents() {
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(team));
+        when(eventRepository.existsByHomeTeamOrAwayTeam(team, team)).thenReturn(false);
+
+        teamService.deleteTeam(1L);
+
+        verify(teamRepository, times(1)).delete(team);
+    }
+
+    @Test
+    void deleteTeam_throwsEntityNotFoundException_whenNotFound() {
+        when(teamRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> teamService.deleteTeam(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+
+        verify(teamRepository, never()).delete(any(Team.class));
+    }
+
+    @Test
+    void deleteTeam_throwsTeamHasEventsException_whenTeamHasEvents() {
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(team));
+        when(eventRepository.existsByHomeTeamOrAwayTeam(team, team)).thenReturn(true);
+
+        assertThatThrownBy(() -> teamService.deleteTeam(1L))
+                .isInstanceOf(TeamHasEventsException.class)
+                .hasMessageContaining("1");
+
+        verify(teamRepository, never()).delete(any(Team.class));
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/tenant/TenantInterceptorTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/tenant/TenantInterceptorTests.java
@@ -6,13 +6,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TenantInterceptorTests {
@@ -43,9 +48,12 @@ class TenantInterceptorTests {
         TenantContext.clear();
     }
 
+    // --- Existing tenant-routing tests (now explicit about HTTP method) ---
+
     @Test
-    void preHandle_withValidHeader_setsTestSchema() {
+    void preHandle_withValidHeader_setsTestSchema() throws Exception {
         when(request.getHeader("X-DB-STATE")).thenReturn("MODIFIED");
+        when(request.getMethod()).thenReturn("GET");
 
         boolean result = tenantInterceptor.preHandle(request, response, handler);
 
@@ -54,8 +62,9 @@ class TenantInterceptorTests {
     }
 
     @Test
-    void preHandle_withInvalidHeader_setsDefaultSchema() {
+    void preHandle_withInvalidHeader_setsDefaultSchema() throws Exception {
         when(request.getHeader("X-DB-STATE")).thenReturn("OTHER");
+        when(request.getMethod()).thenReturn("GET");
 
         boolean result = tenantInterceptor.preHandle(request, response, handler);
 
@@ -64,8 +73,9 @@ class TenantInterceptorTests {
     }
 
     @Test
-    void preHandle_withoutHeader_setsDefaultSchema() {
+    void preHandle_withoutHeader_setsDefaultSchema() throws Exception {
         when(request.getHeader("X-DB-STATE")).thenReturn(null);
+        when(request.getMethod()).thenReturn("GET");
 
         boolean result = tenantInterceptor.preHandle(request, response, handler);
 
@@ -74,8 +84,9 @@ class TenantInterceptorTests {
     }
 
     @Test
-    void preHandle_withDifferentCaseHeaderValue_setsTestSchema() {
+    void preHandle_withDifferentCaseHeaderValue_setsTestSchema() throws Exception {
         when(request.getHeader("X-DB-STATE")).thenReturn("modified");
+        when(request.getMethod()).thenReturn("GET");
 
         boolean result = tenantInterceptor.preHandle(request, response, handler);
 
@@ -90,5 +101,53 @@ class TenantInterceptorTests {
         tenantInterceptor.afterCompletion(request, response, handler, null);
 
         assertThat(TenantContext.getCurrentTenant()).isNull();
+    }
+
+    // --- Mutating-method blocking tests ---
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "PATCH", "DELETE"})
+    void preHandle_mutatingMethodWithoutTestHeader_returns403(String method) throws Exception {
+        when(request.getHeader("X-DB-STATE")).thenReturn(null);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getRequestURI()).thenReturn("/api/teams");
+
+        StringWriter stringWriter = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+
+        boolean result = tenantInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isFalse();
+        verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+        verify(response).setContentType("application/json");
+
+        String body = stringWriter.toString();
+        assertThat(body).contains("\"status\":403");
+        assertThat(body).contains("Write operations require the X-DB-STATE: MODIFIED header");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "PATCH", "DELETE"})
+    void preHandle_mutatingMethodWithTestHeader_allowsRequest(String method) throws Exception {
+        when(request.getHeader("X-DB-STATE")).thenReturn("MODIFIED");
+        when(request.getMethod()).thenReturn(method);
+
+        boolean result = tenantInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        assertThat(TenantContext.getCurrentTenant()).isEqualTo("test_db");
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test
+    void preHandle_getWithoutTestHeader_allowsRequest() throws Exception {
+        when(request.getHeader("X-DB-STATE")).thenReturn(null);
+        when(request.getMethod()).thenReturn("GET");
+
+        boolean result = tenantInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        assertThat(TenantContext.getCurrentTenant()).isEqualTo("default_db");
+        verify(response, never()).setStatus(anyInt());
     }
 }


### PR DESCRIPTION
- Added check in `TenantInterceptor` for mutating HTTP methods (POST, PUT, PATCH, DELETE) and to block them unless `X-DB-STATE: MODIFIED` was present (switches to test db)
- Added `TeamPlayer` model class so `squad` is no longer just a JSON string
- Added `TeamPlayerListConverted` to handle the JSON conversion for `List<TeamPlater>`
- Added `TeamRequest`, `PlayerRequest`, and `TeamStatsRequest` dtos
    - Added `toEntity()` to each class for easy mapping
- Reorganized response dtos into their own package
- Added `createTeam`, `updateTeam`, and `deleteTeam` methods to the `TeamService`
- Added new `TeamHasEventsException` for when `deleteTeam` is called but the team is still attached to some events
- Added CUD endpoitns to `TeamController` with proper swagger documentation
- Added appropriate tests
- closes #14 