### PR TITLE
Create CUD Endpoints for Events

### DIFF
--- a/src/main/java/com/snodgrass/fifa_api/config/ApiHeaders.java
+++ b/src/main/java/com/snodgrass/fifa_api/config/ApiHeaders.java
@@ -1,0 +1,10 @@
+package com.snodgrass.fifa_api.config;
+
+public final class ApiHeaders {
+    public static final String TEST_HEADER = "X-DB-STATE";
+    public static final String TEST_HEADER_VALUE = "MODIFIED";
+
+    private ApiHeaders() {
+        // Prevent instantiation
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
@@ -1,5 +1,7 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.config.ApiHeaders;
+import com.snodgrass.fifa_api.dto.request.EventRequest;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
@@ -8,10 +10,13 @@ import com.snodgrass.fifa_api.service.EventService;
 import com.snodgrass.fifa_api.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -73,5 +78,53 @@ public class EventController {
             @Parameter(description = "Team ID") @PathVariable Long teamId) {
         log.debug("GET /api/events/team/{} - Fetching events by team id", teamId);
         return ResponseEntity.ok(eventService.getEventsByTeam(teamService.getTeamById(teamId)).stream().map(EventResponse::from).toList());
+    }
+
+    @Operation(summary = "Create a new event (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "201", description = "Event created successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @PostMapping
+    public ResponseEntity<EventResponse> createEvent(@Valid @RequestBody EventRequest eventRequest) {
+        log.debug("POST /api/events - Creating event");
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(EventResponse.from(eventService.createEvent(eventRequest)));
+    }
+
+    @Operation(summary = "Update an existing event (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "200", description = "Event updated successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PutMapping("/{id}")
+    public ResponseEntity<EventResponse> updateEvent(
+            @Parameter(description = "Event ID") @PathVariable Long id,
+            @Valid @RequestBody EventRequest eventRequest) {
+        log.debug("PUT /api/events/{} - Updating event", id);
+        return ResponseEntity.ok(EventResponse.from(eventService.updateEvent(id, eventRequest)));
+    }
+
+    @Operation(summary = "Delete an event (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "204", description = "Event deleted successfully")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEvent(
+            @Parameter(description = "Event ID") @PathVariable Long id) {
+        log.debug("DELETE /api/events/{} - Deleting event", id);
+        eventService.deleteEvent(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.config.ApiHeaders;
 import com.snodgrass.fifa_api.dto.request.TeamRequest;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
@@ -52,13 +53,13 @@ public class TeamController {
     }
 
     @Operation(summary = "Create a new team (test database only)",
-            description = "Requires the X-DB-STATE: MODIFIED header to target the test database. "
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
                     + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = "X-DB-STATE", in = ParameterIn.HEADER, required = true,
-                    description = "Must be 'MODIFIED' to enable write operations on the test database"))
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "201", description = "Team created successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid X-DB-STATE header")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
     @PostMapping
     public ResponseEntity<TeamDetailResponse> createTeam(@Valid @RequestBody TeamRequest teamRequest) {
         log.debug("POST /api/teams - Creating team");
@@ -67,13 +68,13 @@ public class TeamController {
     }
 
     @Operation(summary = "Update an existing team (test database only)",
-            description = "Requires the X-DB-STATE: MODIFIED header to target the test database. "
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
                     + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = "X-DB-STATE", in = ParameterIn.HEADER, required = true,
-                    description = "Must be 'MODIFIED' to enable write operations on the test database"))
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "200", description = "Team updated successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid X-DB-STATE header")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
     @ApiResponse(responseCode = "404", description = "Team not found")
     @PutMapping("/{id}")
     public ResponseEntity<TeamDetailResponse> updateTeam(
@@ -84,12 +85,12 @@ public class TeamController {
     }
 
     @Operation(summary = "Delete a team (test database only)",
-            description = "Requires the X-DB-STATE: MODIFIED header to target the test database. "
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
                     + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = "X-DB-STATE", in = ParameterIn.HEADER, required = true,
-                    description = "Must be 'MODIFIED' to enable write operations on the test database"))
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "204", description = "Team deleted successfully")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid X-DB-STATE header")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
     @ApiResponse(responseCode = "404", description = "Team not found")
     @ApiResponse(responseCode = "409", description = "Team has associated events")
     @DeleteMapping("/{id}")

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/EventRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/EventRequest.java
@@ -1,0 +1,83 @@
+package com.snodgrass.fifa_api.dto.request;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record EventRequest(
+        @NotNull
+        Integer matchNumber,
+
+        @NotNull
+        Stage stage,
+
+        Group groupLetter,
+
+        Long homeTeamId,
+
+        Long awayTeamId,
+
+        String homeTeamPlaceholder,
+
+        String awayTeamPlaceholder,
+
+        @NotNull
+        LocalDate matchDate,
+
+        LocalTime kickoffTime,
+
+        LocalDateTime kickoffUtc,
+
+        @NotBlank @Size(max = 100)
+        String arenaName,
+
+        @NotBlank @Size(max = 100)
+        String city,
+
+        @NotNull
+        MatchStatus status,
+
+        Integer homeScore,
+
+        Integer awayScore,
+
+        Long winnerTeamId,
+
+        Boolean isDraw,
+
+        boolean hasExtraTime,
+
+        boolean hasPenalties
+) {
+        public Event toEntity() {
+                Event event = new Event();
+                event.setMatchNumber(this.matchNumber);
+                event.setStage(this.stage);
+                event.setGroupLetter(this.groupLetter);
+                event.setHomeTeamPlaceholder(this.homeTeamPlaceholder);
+                event.setAwayTeamPlaceholder(this.awayTeamPlaceholder);
+                event.setMatchDate(this.matchDate);
+                event.setKickoffTime(this.kickoffTime);
+                event.setKickoffUtc(this.kickoffUtc);
+                event.setArenaName(this.arenaName);
+                event.setCity(this.city);
+                event.setStatus(this.status);
+                event.setHomeScore(this.homeScore);
+                event.setAwayScore(this.awayScore);
+                event.setIsDraw(this.isDraw);
+                event.setHasExtraTime(this.hasExtraTime);
+                event.setHasPenalties(this.hasPenalties);
+                event.setCreatedAt(LocalDateTime.now());
+                event.setUpdatedAt(LocalDateTime.now());
+
+                return event;
+        }
+}

--- a/src/main/java/com/snodgrass/fifa_api/service/EventService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/EventService.java
@@ -1,11 +1,13 @@
 package com.snodgrass.fifa_api.service;
 
+import com.snodgrass.fifa_api.dto.request.EventRequest;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;
 import com.snodgrass.fifa_api.repository.EventRepository;
+import com.snodgrass.fifa_api.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EventService {
     private final EventRepository eventRepository;
+    private final TeamRepository teamRepository;
 
     public List<Event> getAllEvents() {
         return eventRepository.findAll();
@@ -40,5 +43,41 @@ public class EventService {
 
     public List<Event> getEventsByTeam(Team team) {
         return eventRepository.findByHomeTeamOrAwayTeam(team, team);
+    }
+
+    public Event createEvent(EventRequest request) {
+        Event event = request.toEntity();
+        resolveTeamReferences(event, request);
+        return eventRepository.save(event);
+    }
+
+    public Event updateEvent(Long id, EventRequest request) {
+        eventRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Event not found with id: " + id));
+        Event event = request.toEntity();
+        event.setId(id);
+        resolveTeamReferences(event, request);
+        return eventRepository.save(event);
+    }
+
+    public void deleteEvent(Long id) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Event not found with id: " + id));
+        eventRepository.delete(event);
+    }
+
+    private void resolveTeamReferences(Event event, EventRequest request) {
+        if (request.homeTeamId() != null) {
+            event.setHomeTeam(teamRepository.findById(request.homeTeamId())
+                    .orElseThrow(() -> new EntityNotFoundException("Home team not found with id: " + request.homeTeamId())));
+        }
+        if (request.awayTeamId() != null) {
+            event.setAwayTeam(teamRepository.findById(request.awayTeamId())
+                    .orElseThrow(() -> new EntityNotFoundException("Away team not found with id: " + request.awayTeamId())));
+        }
+        if (request.winnerTeamId() != null) {
+            event.setWinnerTeam(teamRepository.findById(request.winnerTeamId())
+                    .orElseThrow(() -> new EntityNotFoundException("Winner team not found with id: " + request.winnerTeamId())));
+        }
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/tenant/TenantInterceptor.java
+++ b/src/main/java/com/snodgrass/fifa_api/tenant/TenantInterceptor.java
@@ -2,6 +2,7 @@ package com.snodgrass.fifa_api.tenant;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.snodgrass.fifa_api.config.ApiHeaders;
 import com.snodgrass.fifa_api.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,19 +26,13 @@ public class TenantInterceptor implements HandlerInterceptor {
     @Value("${app.tenant.test-schema}")
     private String testSchema;
 
-    @Value("${app.tenant.http-test-header}")
-    private String httpTestHeader;
-
-    @Value("${app.tenant.http-test-header-value}")
-    private String httpTestHeaderValue;
-
     private static final Set<String> MUTATING_METHODS = Set.of("POST", "PUT", "PATCH", "DELETE");
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @Override
     public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) throws IOException {
-        String tenant = request.getHeader(httpTestHeader);
-        boolean isTestContext = httpTestHeaderValue.equalsIgnoreCase(tenant);
+        String tenant = request.getHeader(ApiHeaders.TEST_HEADER);
+        boolean isTestContext = ApiHeaders.TEST_HEADER_VALUE.equalsIgnoreCase(tenant);
 
         if (isTestContext) {
             TenantContext.setCurrentTenant(testSchema);
@@ -47,14 +42,14 @@ public class TenantInterceptor implements HandlerInterceptor {
 
         // CUD Http Methods are only to be used on the test database
         if (MUTATING_METHODS.contains(request.getMethod()) && !isTestContext) {
-            log.warn("Blocked {} request to {} — missing or invalid {} header", request.getMethod(), request.getRequestURI(), httpTestHeader);
+            log.warn("Blocked {} request to {} — missing or invalid {} header", request.getMethod(), request.getRequestURI(), ApiHeaders.TEST_HEADER);
 
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
             ErrorResponse errorResponse = new ErrorResponse(
                     HttpServletResponse.SC_FORBIDDEN,
-                    "Write operations require the " + httpTestHeader + ": " + httpTestHeaderValue + " header",
+                    "Write operations require the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header",
                     LocalDateTime.now()
             );
             OBJECT_MAPPER.writeValue(response.getWriter(), errorResponse);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,3 @@ spring.datasource.password=${DB_PASSWORD}
 # Schema names for prod and testing
 app.tenant.default-schema=fifa_world_cup
 app.tenant.test-schema=fifa_world_cup_test
-
-# Hibernate multi-tenancy config
-app.tenant.http-test-header=X-DB-STATE
-app.tenant.http-test-header-value=MODIFIED

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.config.ApiHeaders;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
@@ -108,7 +109,7 @@ class ControllerIntegrationTests {
 
         ResponseEntity<TeamDetailResponse> response = restClient.post()
                 .uri("/api/teams")
-                .header("X-DB-STATE", "MODIFIED")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(json)
                 .retrieve()
@@ -127,7 +128,7 @@ class ControllerIntegrationTests {
         String createName = "Update Pre " + createCode;
         ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
                 .uri("/api/teams")
-                .header("X-DB-STATE", "MODIFIED")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson(createName, createCode))
                 .retrieve()
@@ -139,7 +140,7 @@ class ControllerIntegrationTests {
         String updateName = "Update Post " + updateCode;
         ResponseEntity<TeamDetailResponse> response = restClient.put()
                 .uri("/api/teams/" + teamId)
-                .header("X-DB-STATE", "MODIFIED")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson(updateName, updateCode))
                 .retrieve()
@@ -157,7 +158,7 @@ class ControllerIntegrationTests {
         String delCode = randomCode();
         ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
                 .uri("/api/teams")
-                .header("X-DB-STATE", "MODIFIED")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson("Delete Test " + delCode, delCode))
                 .retrieve()
@@ -167,7 +168,7 @@ class ControllerIntegrationTests {
 
         ResponseEntity<Void> response = restClient.delete()
                 .uri("/api/teams/" + teamId)
-                .header("X-DB-STATE", "MODIFIED")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .retrieve()
                 .toBodilessEntity();
 

--- a/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
@@ -1,5 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.request.EventRequest;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
@@ -24,7 +25,9 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class EventControllerTests {
@@ -185,6 +188,82 @@ class EventControllerTests {
         when(teamService.getTeamById(99L)).thenThrow(new EntityNotFoundException("Team not found with id: 99"));
 
         assertThatThrownBy(() -> eventController.getEventsByTeam(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // CUD helpers
+
+    private EventRequest validEventRequest() {
+        return new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+    }
+
+    // createEvent
+
+    @Test
+    void createEvent_returns201WithBody() {
+        EventRequest request = validEventRequest();
+        when(eventService.createEvent(any(EventRequest.class))).thenReturn(event);
+
+        ResponseEntity<EventResponse> response = eventController.createEvent(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().matchNumber()).isEqualTo(1);
+        verify(eventService, times(1)).createEvent(any(EventRequest.class));
+    }
+
+    // updateEvent
+
+    @Test
+    void updateEvent_returns200WithBody() {
+        EventRequest request = validEventRequest();
+        when(eventService.updateEvent(eq(1L), any(EventRequest.class))).thenReturn(event);
+
+        ResponseEntity<EventResponse> response = eventController.updateEvent(1L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().matchNumber()).isEqualTo(1);
+        verify(eventService, times(1)).updateEvent(eq(1L), any(EventRequest.class));
+    }
+
+    @Test
+    void updateEvent_throwsEntityNotFoundException_whenNotFound() {
+        EventRequest request = validEventRequest();
+        when(eventService.updateEvent(eq(99L), any(EventRequest.class)))
+                .thenThrow(new EntityNotFoundException("Event not found with id: 99"));
+
+        assertThatThrownBy(() -> eventController.updateEvent(99L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // deleteEvent
+
+    @Test
+    void deleteEvent_returns204() {
+        doNothing().when(eventService).deleteEvent(1L);
+
+        ResponseEntity<Void> response = eventController.deleteEvent(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+        verify(eventService, times(1)).deleteEvent(1L);
+    }
+
+    @Test
+    void deleteEvent_throwsEntityNotFoundException_whenNotFound() {
+        doThrow(new EntityNotFoundException("Event not found with id: 99"))
+                .when(eventService).deleteEvent(99L);
+
+        assertThatThrownBy(() -> eventController.deleteEvent(99L))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("99");
     }

--- a/src/test/java/com/snodgrass/fifa_api/dto/EventRequestTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/dto/EventRequestTests.java
@@ -1,0 +1,210 @@
+package com.snodgrass.fifa_api.dto;
+
+import com.snodgrass.fifa_api.dto.request.EventRequest;
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventRequestTests {
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private EventRequest validRequest() {
+        return new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), LocalTime.of(18, 0), LocalDateTime.of(2026, 6, 11, 22, 0),
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+    }
+
+    @Test
+    void validRequest_hasNoViolations() {
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(validRequest());
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void validRequest_withNullOptionals_hasNoViolations() {
+        EventRequest request = new EventRequest(1, Stage.QUARTERFINAL, null,
+                null, null, "Winner Group A", "Winner Group B",
+                LocalDate.of(2026, 7, 4), null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    // matchNumber
+    @Test
+    void nullMatchNumber_hasViolation() {
+        EventRequest request = new EventRequest(null, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("matchNumber"));
+    }
+
+    // stage
+    @Test
+    void nullStage_hasViolation() {
+        EventRequest request = new EventRequest(1, null, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("stage"));
+    }
+
+    // matchDate
+    @Test
+    void nullMatchDate_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                null, null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("matchDate"));
+    }
+
+    // arenaName
+    @Test
+    void nullArenaName_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                null, "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("arenaName"));
+    }
+
+    @Test
+    void blankArenaName_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("arenaName"));
+    }
+
+    @Test
+    void arenaNameTooLong_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "A".repeat(101), "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("arenaName"));
+    }
+
+    // city
+    @Test
+    void nullCity_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", null,
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("city"));
+    }
+
+    @Test
+    void blankCity_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("city"));
+    }
+
+
+    @Test
+    void cityTooLong_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "A".repeat(101),
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("city"));
+    }
+
+    // status
+    @Test
+    void nullStatus_hasViolation() {
+        EventRequest request = new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "New York",
+                null, null, null, null, null, false, false);
+        Set<ConstraintViolation<EventRequest>> violations = validator.validate(request);
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("status"));
+    }
+
+    // toEntity
+
+    @Test
+    void toEntity_mapsAllScalarFields() {
+        EventRequest request = validRequest();
+        Event entity = request.toEntity();
+
+        assertThat(entity.getMatchNumber()).isEqualTo(1);
+        assertThat(entity.getStage()).isEqualTo(Stage.GROUP);
+        assertThat(entity.getGroupLetter()).isEqualTo(Group.A);
+        assertThat(entity.getMatchDate()).isEqualTo(LocalDate.of(2026, 6, 11));
+        assertThat(entity.getKickoffTime()).isEqualTo(LocalTime.of(18, 0));
+        assertThat(entity.getKickoffUtc()).isEqualTo(LocalDateTime.of(2026, 6, 11, 22, 0));
+        assertThat(entity.getArenaName()).isEqualTo("MetLife Stadium");
+        assertThat(entity.getCity()).isEqualTo("New York");
+        assertThat(entity.getStatus()).isEqualTo(MatchStatus.SCHEDULED);
+        assertThat(entity.getIsDraw()).isNull();
+        assertThat(entity.isHasExtraTime()).isFalse();
+        assertThat(entity.isHasPenalties()).isFalse();
+    }
+
+    @Test
+    void toEntity_doesNotSetTeamReferences() {
+        EventRequest request = validRequest();
+        Event entity = request.toEntity();
+
+        assertThat(entity.getHomeTeam()).isNull();
+        assertThat(entity.getAwayTeam()).isNull();
+        assertThat(entity.getWinnerTeam()).isNull();
+    }
+
+    @Test
+    void toEntity_setsTimestamps() {
+        EventRequest request = validRequest();
+        Event entity = request.toEntity();
+
+        assertThat(entity.getCreatedAt()).isNotNull();
+        assertThat(entity.getUpdatedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
@@ -1,11 +1,13 @@
 package com.snodgrass.fifa_api.service;
 
+import com.snodgrass.fifa_api.dto.request.EventRequest;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;
 import com.snodgrass.fifa_api.repository.EventRepository;
+import com.snodgrass.fifa_api.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,9 @@ class EventServiceTests {
 
     @Mock
     private EventRepository eventRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
 
     @InjectMocks
     private EventService eventService;
@@ -165,5 +170,160 @@ class EventServiceTests {
         List<Event> result = eventService.getEventsByTeam(team);
 
         assertThat(result).isEmpty();
+    }
+
+    // CUD helpers
+
+    private EventRequest validEventRequest() {
+        return new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+    }
+
+    private EventRequest knockoutEventRequest() {
+        return new EventRequest(49, Stage.QUARTERFINAL, null,
+                null, null, "Winner Group A", "Runner-up Group B",
+                LocalDate.of(2026, 7, 4), null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+    }
+
+    private Team createTeam(Long id, String name) {
+        Team t = new Team();
+        t.setId(id);
+        t.setCountryName(name);
+        t.setCountryCode(name.substring(0, 3).toUpperCase());
+        t.setGroupLetter(Group.A);
+        t.setCreatedAt(LocalDateTime.now());
+        t.setUpdatedAt(LocalDateTime.now());
+        return t;
+    }
+
+    // createEvent
+
+    @Test
+    void createEvent_savesAndReturnsEvent() {
+        EventRequest request = validEventRequest();
+        Team home = createTeam(1L, "Brazil");
+        Team away = createTeam(2L, "Argentina");
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(home));
+        when(teamRepository.findById(2L)).thenReturn(Optional.of(away));
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> {
+            Event saved = invocation.getArgument(0);
+            saved.setId(1L);
+            return saved;
+        });
+
+        Event result = eventService.createEvent(request);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getMatchNumber()).isEqualTo(1);
+        assertThat(result.getHomeTeam()).isEqualTo(home);
+        assertThat(result.getAwayTeam()).isEqualTo(away);
+        verify(eventRepository, times(1)).save(any(Event.class));
+    }
+
+    @Test
+    void createEvent_withNullTeamIds_savesWithoutTeams() {
+        EventRequest request = knockoutEventRequest();
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> {
+            Event saved = invocation.getArgument(0);
+            saved.setId(1L);
+            return saved;
+        });
+
+        Event result = eventService.createEvent(request);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getHomeTeam()).isNull();
+        assertThat(result.getAwayTeam()).isNull();
+        assertThat(result.getHomeTeamPlaceholder()).isEqualTo("Winner Group A");
+        verify(teamRepository, never()).findById(any());
+    }
+
+    @Test
+    void createEvent_throwsEntityNotFoundException_whenHomeTeamNotFound() {
+        EventRequest request = validEventRequest();
+        when(teamRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.createEvent(request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Home team not found");
+
+        verify(eventRepository, never()).save(any(Event.class));
+    }
+
+    @Test
+    void createEvent_throwsEntityNotFoundException_whenAwayTeamNotFound() {
+        EventRequest request = validEventRequest();
+        Team home = createTeam(1L, "Brazil");
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(home));
+        when(teamRepository.findById(2L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.createEvent(request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Away team not found");
+
+        verify(eventRepository, never()).save(any(Event.class));
+    }
+
+    // updateEvent
+
+    @Test
+    void updateEvent_savesAndReturnsUpdatedEvent() {
+        EventRequest request = validEventRequest();
+        Team home = createTeam(1L, "Brazil");
+        Team away = createTeam(2L, "Argentina");
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(teamRepository.findById(1L)).thenReturn(Optional.of(home));
+        when(teamRepository.findById(2L)).thenReturn(Optional.of(away));
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> {
+            Event saved = invocation.getArgument(0);
+            saved.setId(1L);
+            return saved;
+        });
+
+        Event result = eventService.updateEvent(1L, request);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getMatchNumber()).isEqualTo(1);
+        verify(eventRepository, times(1)).findById(1L);
+        verify(eventRepository, times(1)).save(any(Event.class));
+    }
+
+    @Test
+    void updateEvent_throwsEntityNotFoundException_whenEventNotFound() {
+        EventRequest request = validEventRequest();
+        when(eventRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.updateEvent(99L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+
+        verify(eventRepository, never()).save(any(Event.class));
+    }
+
+    // deleteEvent
+
+    @Test
+    void deleteEvent_deletesEvent() {
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+
+        eventService.deleteEvent(1L);
+
+        verify(eventRepository, times(1)).delete(event);
+    }
+
+    @Test
+    void deleteEvent_throwsEntityNotFoundException_whenNotFound() {
+        when(eventRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.deleteEvent(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+
+        verify(eventRepository, never()).delete(any(Event.class));
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/tenant/TenantInterceptorTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/tenant/TenantInterceptorTests.java
@@ -38,8 +38,6 @@ class TenantInterceptorTests {
     void setUp() {
         ReflectionTestUtils.setField(tenantInterceptor, "defaultSchema", "default_db");
         ReflectionTestUtils.setField(tenantInterceptor, "testSchema", "test_db");
-        ReflectionTestUtils.setField(tenantInterceptor, "httpTestHeader", "X-DB-STATE");
-        ReflectionTestUtils.setField(tenantInterceptor, "httpTestHeaderValue", "MODIFIED");
         TenantContext.clear();
     }
 

--- a/src/test/resources/application-ci.properties
+++ b/src/test/resources/application-ci.properties
@@ -11,7 +11,3 @@ spring.datasource.password=${DB_PASSWORD}
 # Schema names for prod and testing
 app.tenant.default-schema=fifa_world_cup
 app.tenant.test-schema=fifa_world_cup_test
-
-# Hibernate multi-tenancy config
-app.tenant.http-test-header=X-DB-STATE
-app.tenant.http-test-header-value=MODIFIED


### PR DESCRIPTION
- Added POST, PUT, and DELETE endpoints for Events in `EventController`
- Created `EventRequest` DTO with validation and a `toEntity()` method, following the same pattern used for Teams
- Updated `EventService` with create, update, and delete methods, including team reference resolution (handles null team IDs for knockout stage events)
- Added Swagger descriptions on all new endpoints explaining they are test database only and require the `X-DB-STATE: MODIFIED` header
- Created `ApiHeaders` constants class so the header name and value live in one place instead of being scattered across files and properties
- Updated `TeamController`, `EventController`, and `TenantInterceptor` to use the new `ApiHeaders` constants
- Removed `app.tenant.http-test-header` and `app.tenant.http-test-header-value` from all property files (`application.properties` and `application-ci.properties`)
- Updated integration tests and `TenantInterceptorTests` to use the constants and removed the now-unnecessary `ReflectionTestUtils` field injections
- Added unit tests for `EventRequest` validation and `toEntity()` mapping
- Added unit tests for the new `EventService` CUD methods (including team resolution and not-found cases)
- Added unit tests for the new `EventController` CUD endpoints
- closes #16 