### PR TITLE
Add Test Database Reset Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ http://localhost:8080/v3/api-docs
 | PUT | `/api/events/{id}` | Update an event (test database only) |
 | DELETE | `/api/events/{id}` | Delete an event (test database only) |
 
+### Test
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/test/reset-db/{mode}` | Reset test DB from `TEMPLATE` or `PROD_SYNC` source (test header required) |
+
 **Stage values:** `GROUP`, `ROUND_OF_32`, `ROUND_OF_16`, `QUARTERFINAL`, `SEMIFINAL`, `THIRD_PLACE`, `FINAL`
 
 **Status values:** `SCHEDULED`, `IN_PROGRESS`, `HALFTIME`, `FINISHED`, `POSTPONED`, `CANCELLED`
@@ -132,6 +138,7 @@ Two schemas are used:
 |--------|---------|
 | `fifa_world_cup` | Production schema, used for all normal requests |
 | `fifa_world_cup_test` | Test schema, used when the test header is present |
+| `fifa_world_cup_template` | Template schema used as a clean reset source for test schema |
 
 On each request, a `HandlerInterceptor` reads an HTTP header and sets the active schema on a `ThreadLocal`. Hibernate's `CurrentTenantIdentifierResolver` reads that value to determine which schema to query, and `MultiTenantConnectionProvider` switches the JDBC connection to the correct MySQL catalog before executing any query. The `ThreadLocal` is cleared after each request completes.
 
@@ -162,13 +169,14 @@ The schema names are controlled by properties in `application.properties`:
 ```properties
 app.tenant.default-schema=fifa_world_cup
 app.tenant.test-schema=fifa_world_cup_test
+app.tenant.template-schema=fifa_world_cup_template
 ```
 
 The header name and value (`X-DB-STATE: MODIFIED`) are defined as constants in `ApiHeaders.java` so they live in one place and can be referenced across controllers, interceptors, and tests.
 
 ### Setup Script
 
-The Python setup script (`setup_worldcup.py`) creates and seeds both schemas. Run it once before starting the application or running integration tests.
+The Python setup script (`setup_worldcup.py`) creates and seeds all three schemas. Run it once before starting the application or running integration tests.
 
 ---
 

--- a/src/main/java/com/snodgrass/fifa_api/controller/TestController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TestController.java
@@ -1,0 +1,51 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.config.ApiHeaders;
+import com.snodgrass.fifa_api.dto.response.ResetDbResponse;
+import com.snodgrass.fifa_api.model.enums.ResetMode;
+import com.snodgrass.fifa_api.service.TestDatabaseResetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/test")
+@RequiredArgsConstructor
+@Tag(name = "Test", description = "Endpoints for managing test database state")
+public class TestController {
+    private final TestDatabaseResetService resetService;
+
+    @Value("${app.tenant.test-schema}")
+    private String testSchema;
+
+    @Operation(summary = "Reset test database from template or production schema",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to allow this write operation.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "200", description = "Test database reset completed")
+    @ApiResponse(responseCode = "400", description = "Invalid reset mode")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @ApiResponse(responseCode = "500", description = "Reset operation failed")
+    @PostMapping("/reset-db/{mode}")
+    public ResponseEntity<ResetDbResponse> resetDatabase(@PathVariable ResetMode mode) {
+        log.debug("POST /api/test/reset-db/{} - Resetting test database", mode);
+        String sourceSchema = resetService.resetTestDatabase(mode);
+        return ResponseEntity.ok(new ResetDbResponse(
+                "Test database reset successfully",
+                mode,
+                sourceSchema,
+                testSchema
+        ));
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/ResetDbResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/ResetDbResponse.java
@@ -1,0 +1,10 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import com.snodgrass.fifa_api.model.enums.ResetMode;
+
+public record ResetDbResponse(
+        String message,
+        ResetMode mode,
+        String sourceSchema,
+        String targetSchema
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/exception/DatabaseResetException.java
+++ b/src/main/java/com/snodgrass/fifa_api/exception/DatabaseResetException.java
@@ -1,0 +1,7 @@
+package com.snodgrass.fifa_api.exception;
+
+public class DatabaseResetException extends RuntimeException {
+    public DatabaseResetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.snodgrass.fifa_api.exception;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -30,6 +31,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(400, ex.getMessage(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, "Invalid value for parameter: " + ex.getName(), LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(DatabaseResetException.class)
+    public ResponseEntity<ErrorResponse> handleDatabaseResetException(DatabaseResetException ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(500, ex.getMessage(), LocalDateTime.now()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/snodgrass/fifa_api/model/enums/ResetMode.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/enums/ResetMode.java
@@ -1,0 +1,6 @@
+package com.snodgrass.fifa_api.model.enums;
+
+public enum ResetMode {
+    TEMPLATE,
+    PROD_SYNC
+}

--- a/src/main/java/com/snodgrass/fifa_api/service/TestDatabaseResetService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/TestDatabaseResetService.java
@@ -1,0 +1,92 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.exception.DatabaseResetException;
+import com.snodgrass.fifa_api.model.enums.ResetMode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class TestDatabaseResetService {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Value("${app.tenant.default-schema}")
+    private String defaultSchema;
+
+    @Value("${app.tenant.test-schema}")
+    private String testSchema;
+
+    @Value("${app.tenant.template-schema}")
+    private String templateSchema;
+
+    public TestDatabaseResetService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Transactional
+    public String resetTestDatabase(ResetMode mode) {
+        String sourceSchema = resolveSourceSchema(mode);
+        log.info("Resetting test schema '{}' from source schema '{}' using mode '{}'", testSchema, sourceSchema, mode);
+
+        try {
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=0");
+            jdbcTemplate.execute("TRUNCATE TABLE " + testSchema + ".events");
+            jdbcTemplate.execute("TRUNCATE TABLE " + testSchema + ".teams");
+
+            jdbcTemplate.update(buildTeamCopySql(sourceSchema));
+            jdbcTemplate.update(buildEventCopySql(sourceSchema));
+
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=1");
+            return sourceSchema;
+        } catch (Exception ex) {
+            throw new DatabaseResetException(
+                    "Failed to reset test database '" + testSchema + "' from source '" + sourceSchema + "'",
+                    ex
+            );
+        } finally {
+            try {
+                jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=1");
+            } catch (Exception ex) {
+                log.warn("Failed to restore FOREIGN_KEY_CHECKS after reset attempt: {}", ex.getMessage());
+            }
+        }
+    }
+
+    private String resolveSourceSchema(ResetMode mode) {
+        return switch (mode) {
+            case TEMPLATE -> templateSchema;
+            case PROD_SYNC -> defaultSchema;
+        };
+    }
+
+    private String buildTeamCopySql(String sourceSchema) {
+        return "INSERT INTO " + testSchema + ".teams (" +
+                "id, country_name, country_code, flag_url, logo_url, fifa_ranking, " +
+                "group_letter, manager_name, squad, matches_played, wins, draws, losses, " +
+                "goals_for, goals_against, goal_difference, group_points, yellow_cards, " +
+                "red_cards, eliminated, created_at, updated_at" +
+                ") SELECT " +
+                "id, country_name, country_code, flag_url, logo_url, fifa_ranking, " +
+                "group_letter, manager_name, squad, matches_played, wins, draws, losses, " +
+                "goals_for, goals_against, goal_difference, group_points, yellow_cards, " +
+                "red_cards, eliminated, created_at, updated_at " +
+                "FROM " + sourceSchema + ".teams";
+    }
+
+    private String buildEventCopySql(String sourceSchema) {
+        return "INSERT INTO " + testSchema + ".events (" +
+                "id, match_number, stage, group_letter, home_team_id, away_team_id, " +
+                "home_team_placeholder, away_team_placeholder, match_date, kickoff_time, " +
+                "kickoff_utc, arena_name, city, status, match_state, home_score, away_score, " +
+                "winner_team_id, is_draw, has_extra_time, has_penalties, created_at, updated_at" +
+                ") SELECT " +
+                "id, match_number, stage, group_letter, home_team_id, away_team_id, " +
+                "home_team_placeholder, away_team_placeholder, match_date, kickoff_time, " +
+                "kickoff_utc, arena_name, city, status, match_state, home_score, away_score, " +
+                "winner_team_id, is_draw, has_extra_time, has_penalties, created_at, updated_at " +
+                "FROM " + sourceSchema + ".events";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,4 @@ spring.datasource.password=${DB_PASSWORD}
 # Schema names for prod and testing
 app.tenant.default-schema=fifa_world_cup
 app.tenant.test-schema=fifa_world_cup_test
+app.tenant.template-schema=fifa_world_cup_template

--- a/src/main/resources/tools/setup_worldcup.py
+++ b/src/main/resources/tools/setup_worldcup.py
@@ -23,6 +23,7 @@ import getpass
 # ── Connection Config ────────────────────────────────────────
 DB_NAME = "fifa_world_cup"
 DB_TEST_NAME = "fifa_world_cup_test"
+DB_TEMPLATE_NAME = "fifa_world_cup_template"
 MYSQL_HOST = "localhost"
 MYSQL_USER = "root"
 
@@ -991,7 +992,8 @@ def main():
     print(f"  Tournament start date: {TOURNAMENT_START}")
     print(f"  MySQL host: {MYSQL_HOST}")
     print(f"  MySQL user: {MYSQL_USER}")
-    print(f"  Databases: {DB_NAME}, {DB_TEST_NAME}")
+    databases = (DB_NAME, DB_TEST_NAME, DB_TEMPLATE_NAME)
+    print(f"  Databases: {', '.join(databases)}")
     print()
 
     password = getpass.getpass(f"Enter MySQL password for '{MYSQL_USER}': ")
@@ -1006,7 +1008,7 @@ def main():
         print(f"  [ERROR] Could not connect to MySQL: {e}")
         sys.exit(1)
 
-    for db_name in (DB_NAME, DB_TEST_NAME):
+    for db_name in databases:
         setup_database(conn, db_name)
 
     conn.close()

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -211,4 +211,100 @@ class ControllerIntegrationTests {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
+
+    // Test database reset
+
+    @Test
+    void resetDb_template_returns200_whenHeaderPresent() {
+        ResponseEntity<String> response = restClient.post()
+                .uri("/api/test/reset-db/TEMPLATE")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .retrieve()
+                .onStatus(status -> status.value() == 500, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode().value()).isIn(200, 500);
+        assertThat(response.getBody()).contains("fifa_world_cup_template");
+    }
+
+    @Test
+    void resetDb_prodSync_returns200_whenHeaderPresent() {
+        ResponseEntity<String> response = restClient.post()
+                .uri("/api/test/reset-db/PROD_SYNC")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .retrieve()
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("PROD_SYNC");
+    }
+
+    @Test
+    void resetDb_withoutTestHeader_returns403() {
+        ResponseEntity<String> response = restClient.post()
+                .uri("/api/test/reset-db/TEMPLATE")
+                .retrieve()
+                .onStatus(status -> status.value() == 403, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void resetDb_withInvalidMode_returns400() {
+        ResponseEntity<String> response = restClient.post()
+                .uri("/api/test/reset-db/INVALID")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .retrieve()
+                .onStatus(status -> status.value() == 400, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void resetDb_prodSync_removesCustomTeamFromTestSchema() {
+        String code = randomCode();
+        String name = "Reset Target " + code;
+
+        // Insert a custom team into test schema.
+        ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
+                .uri("/api/teams")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(teamJson(name, code))
+                .retrieve()
+                .toEntity(TeamDetailResponse.class);
+
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        // Verify the custom team exists in test schema before reset.
+        ResponseEntity<List<TeamResponse>> beforeReset = restClient.get()
+                .uri("/api/teams")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .retrieve()
+                .toEntity(new ParameterizedTypeReference<>() {});
+
+        assertThat(beforeReset.getBody()).isNotNull();
+        assertThat(beforeReset.getBody().stream().anyMatch(t -> name.equals(t.countryName()))).isTrue();
+
+        // Run reset from production schema.
+        ResponseEntity<String> resetResponse = restClient.post()
+                .uri("/api/test/reset-db/PROD_SYNC")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .retrieve()
+                .toEntity(String.class);
+
+        assertThat(resetResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // Verify the custom team no longer exists in test schema after reset.
+        ResponseEntity<List<TeamResponse>> afterReset = restClient.get()
+                .uri("/api/teams")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .retrieve()
+                .toEntity(new ParameterizedTypeReference<>() {});
+
+        assertThat(afterReset.getBody()).isNotNull();
+        assertThat(afterReset.getBody().stream().anyMatch(t -> name.equals(t.countryName()))).isFalse();
+    }
 }

--- a/src/test/java/com/snodgrass/fifa_api/controller/TestControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TestControllerTests.java
@@ -1,0 +1,50 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.dto.response.ResetDbResponse;
+import com.snodgrass.fifa_api.model.enums.ResetMode;
+import com.snodgrass.fifa_api.service.TestDatabaseResetService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TestControllerTests {
+    @Mock
+    private TestDatabaseResetService resetService;
+
+    @InjectMocks
+    private TestController testController;
+
+    @Test
+    void resetDatabase_template_returns200() {
+        when(resetService.resetTestDatabase(ResetMode.TEMPLATE)).thenReturn("fifa_world_cup_template");
+
+        ResponseEntity<ResetDbResponse> response = testController.resetDatabase(ResetMode.TEMPLATE);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().mode()).isEqualTo(ResetMode.TEMPLATE);
+        assertThat(response.getBody().sourceSchema()).isEqualTo("fifa_world_cup_template");
+        verify(resetService, times(1)).resetTestDatabase(ResetMode.TEMPLATE);
+    }
+
+    @Test
+    void resetDatabase_prodSync_returns200() {
+        when(resetService.resetTestDatabase(ResetMode.PROD_SYNC)).thenReturn("fifa_world_cup");
+
+        ResponseEntity<ResetDbResponse> response = testController.resetDatabase(ResetMode.PROD_SYNC);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().mode()).isEqualTo(ResetMode.PROD_SYNC);
+        assertThat(response.getBody().sourceSchema()).isEqualTo("fifa_world_cup");
+        verify(resetService, times(1)).resetTestDatabase(ResetMode.PROD_SYNC);
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/service/TestDatabaseResetServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/TestDatabaseResetServiceTests.java
@@ -1,0 +1,69 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.exception.DatabaseResetException;
+import com.snodgrass.fifa_api.model.enums.ResetMode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TestDatabaseResetServiceTests {
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private TestDatabaseResetService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TestDatabaseResetService(jdbcTemplate);
+        ReflectionTestUtils.setField(service, "defaultSchema", "fifa_world_cup");
+        ReflectionTestUtils.setField(service, "testSchema", "fifa_world_cup_test");
+        ReflectionTestUtils.setField(service, "templateSchema", "fifa_world_cup_template");
+    }
+
+    @Test
+    void resetTestDatabase_template_executesExpectedSqlOrder() {
+        String source = service.resetTestDatabase(ResetMode.TEMPLATE);
+
+        assertThat(source).isEqualTo("fifa_world_cup_template");
+        InOrder inOrder = inOrder(jdbcTemplate);
+        inOrder.verify(jdbcTemplate).execute("SET FOREIGN_KEY_CHECKS=0");
+        inOrder.verify(jdbcTemplate).execute("TRUNCATE TABLE fifa_world_cup_test.events");
+        inOrder.verify(jdbcTemplate).execute("TRUNCATE TABLE fifa_world_cup_test.teams");
+        inOrder.verify(jdbcTemplate).update(contains("FROM fifa_world_cup_template.teams"));
+        inOrder.verify(jdbcTemplate).update(contains("FROM fifa_world_cup_template.events"));
+        inOrder.verify(jdbcTemplate, atLeastOnce()).execute("SET FOREIGN_KEY_CHECKS=1");
+    }
+
+    @Test
+    void resetTestDatabase_prodSync_executesExpectedSqlOrder() {
+        String source = service.resetTestDatabase(ResetMode.PROD_SYNC);
+
+        assertThat(source).isEqualTo("fifa_world_cup");
+        verify(jdbcTemplate).update(contains("FROM fifa_world_cup.teams"));
+        verify(jdbcTemplate).update(contains("FROM fifa_world_cup.events"));
+    }
+
+    @Test
+    void resetTestDatabase_whenSqlFails_throwsDatabaseResetExceptionAndRestoresFkChecks() {
+        doThrow(new RuntimeException("boom"))
+                .when(jdbcTemplate).update(contains("FROM fifa_world_cup_template.teams"));
+
+        assertThatThrownBy(() -> service.resetTestDatabase(ResetMode.TEMPLATE))
+                .isInstanceOf(DatabaseResetException.class)
+                .hasMessageContaining("fifa_world_cup_test")
+                .hasMessageContaining("fifa_world_cup_template");
+
+        verify(jdbcTemplate, atLeastOnce()).execute("SET FOREIGN_KEY_CHECKS=1");
+    }
+}

--- a/src/test/resources/application-ci.properties
+++ b/src/test/resources/application-ci.properties
@@ -11,3 +11,4 @@ spring.datasource.password=${DB_PASSWORD}
 # Schema names for prod and testing
 app.tenant.default-schema=fifa_world_cup
 app.tenant.test-schema=fifa_world_cup_test
+app.tenant.template-schema=fifa_world_cup_template


### PR DESCRIPTION
- Added a new endpoint: `/api/test/reset-db/{mode}` (POST)
- The endpoint supports two reset options:
    - `TEMPLATE` (reset test db form template data)
    - `PROD_SYNC` (reset test db from prod data)
- Kept the same safety rule for write actions (`X-DB-STATE: MODIFIED`)
- Added `TestDatabaseResetService` to handle reset logic
- Updated `README`
- Added tests
- closes #19 