### PR TITLE
Move Test Endpoints To TestController

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ http://localhost:8080/v3/api-docs
 | GET | `/api/teams` | Get all teams |
 | GET | `/api/teams/{id}` | Get team by ID |
 | GET | `/api/teams/group/{group}` | Get teams by group (A–L) |
-| POST | `/api/teams` | Create a new team (test database only) |
-| PUT | `/api/teams/{id}` | Update a team (test database only) |
-| DELETE | `/api/teams/{id}` | Delete a team (test database only) |
 
 ### Events
 
@@ -110,15 +107,18 @@ http://localhost:8080/v3/api-docs
 | GET | `/api/events/stage/{stage}` | Get events by stage |
 | GET | `/api/events/status/{status}` | Get events by status |
 | GET | `/api/events/team/{teamId}` | Get all events involving a team |
-| POST | `/api/events` | Create a new event (test database only) |
-| PUT | `/api/events/{id}` | Update an event (test database only) |
-| DELETE | `/api/events/{id}` | Delete an event (test database only) |
 
 ### Test
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | POST | `/api/test/reset-db/{mode}` | Reset test DB from `TEMPLATE` or `PROD_SYNC` source (test header required) |
+| POST | `/api/test/teams` | Create a new team (test database only) |
+| PUT | `/api/test/teams/{id}` | Update a team (test database only) |
+| DELETE | `/api/test/teams/{id}` | Delete a team (test database only) |
+| POST | `/api/test/events` | Create a new event (test database only) |
+| PUT | `/api/test/events/{id}` | Update an event (test database only) |
+| DELETE | `/api/test/events/{id}` | Delete an event (test database only) |
 
 **Stage values:** `GROUP`, `ROUND_OF_32`, `ROUND_OF_16`, `QUARTERFINAL`, `SEMIFINAL`, `THIRD_PLACE`, `FINAL`
 

--- a/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/EventController.java
@@ -1,7 +1,6 @@
 package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.config.ApiHeaders;
-import com.snodgrass.fifa_api.dto.request.EventRequest;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.model.enums.MatchStatus;
@@ -10,13 +9,10 @@ import com.snodgrass.fifa_api.service.EventService;
 import com.snodgrass.fifa_api.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -78,53 +74,5 @@ public class EventController {
             @Parameter(description = "Team ID") @PathVariable Long teamId) {
         log.debug("GET /api/events/team/{} - Fetching events by team id", teamId);
         return ResponseEntity.ok(eventService.getEventsByTeam(teamService.getTeamById(teamId)).stream().map(EventResponse::from).toList());
-    }
-
-    @Operation(summary = "Create a new event (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
-    @ApiResponse(responseCode = "201", description = "Event created successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid request body")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
-    @PostMapping
-    public ResponseEntity<EventResponse> createEvent(@Valid @RequestBody EventRequest eventRequest) {
-        log.debug("POST /api/events - Creating event");
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(EventResponse.from(eventService.createEvent(eventRequest)));
-    }
-
-    @Operation(summary = "Update an existing event (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
-    @ApiResponse(responseCode = "200", description = "Event updated successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid request body")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
-    @ApiResponse(responseCode = "404", description = "Event not found")
-    @PutMapping("/{id}")
-    public ResponseEntity<EventResponse> updateEvent(
-            @Parameter(description = "Event ID") @PathVariable Long id,
-            @Valid @RequestBody EventRequest eventRequest) {
-        log.debug("PUT /api/events/{} - Updating event", id);
-        return ResponseEntity.ok(EventResponse.from(eventService.updateEvent(id, eventRequest)));
-    }
-
-    @Operation(summary = "Delete an event (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
-    @ApiResponse(responseCode = "204", description = "Event deleted successfully")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
-    @ApiResponse(responseCode = "404", description = "Event not found")
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteEvent(
-            @Parameter(description = "Event ID") @PathVariable Long id) {
-        log.debug("DELETE /api/events/{} - Deleting event", id);
-        eventService.deleteEvent(id);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TeamController.java
@@ -1,20 +1,15 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.config.ApiHeaders;
-import com.snodgrass.fifa_api.dto.request.TeamRequest;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.model.enums.Group;
 import com.snodgrass.fifa_api.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -50,54 +45,5 @@ public class TeamController {
             @Parameter(description = "Group letter (A-L)") @PathVariable Group group) {
         log.debug("GET /api/teams/group/{} - Fetching teams by group", group);
         return ResponseEntity.ok(teamService.getTeamsByGroup(group).stream().map(TeamResponse::from).toList());
-    }
-
-    @Operation(summary = "Create a new team (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
-    @ApiResponse(responseCode = "201", description = "Team created successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid request body")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
-    @PostMapping
-    public ResponseEntity<TeamDetailResponse> createTeam(@Valid @RequestBody TeamRequest teamRequest) {
-        log.debug("POST /api/teams - Creating team");
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(TeamDetailResponse.from(teamService.createTeam(teamRequest)));
-    }
-
-    @Operation(summary = "Update an existing team (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
-    @ApiResponse(responseCode = "200", description = "Team updated successfully")
-    @ApiResponse(responseCode = "400", description = "Invalid request body")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
-    @ApiResponse(responseCode = "404", description = "Team not found")
-    @PutMapping("/{id}")
-    public ResponseEntity<TeamDetailResponse> updateTeam(
-            @Parameter(description = "Team ID") @PathVariable Long id,
-            @Valid @RequestBody TeamRequest teamRequest) {
-        log.debug("PUT /api/teams/{} - Updating team", id);
-        return ResponseEntity.ok(TeamDetailResponse.from(teamService.updateTeam(id, teamRequest)));
-    }
-
-    @Operation(summary = "Delete a team (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
-    @ApiResponse(responseCode = "204", description = "Team deleted successfully")
-    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
-    @ApiResponse(responseCode = "404", description = "Team not found")
-    @ApiResponse(responseCode = "409", description = "Team has associated events")
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteTeam(
-            @Parameter(description = "Team ID") @PathVariable Long id) {
-        log.debug("DELETE /api/teams/{} - Deleting team", id);
-        teamService.deleteTeam(id);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/controller/TestController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TestController.java
@@ -1,20 +1,31 @@
 package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.config.ApiHeaders;
+import com.snodgrass.fifa_api.dto.request.EventRequest;
+import com.snodgrass.fifa_api.dto.request.TeamRequest;
+import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.dto.response.ResetDbResponse;
+import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.model.enums.ResetMode;
+import com.snodgrass.fifa_api.service.EventService;
+import com.snodgrass.fifa_api.service.TeamService;
 import com.snodgrass.fifa_api.service.TestDatabaseResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +36,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Test", description = "Endpoints for managing test database state")
 public class TestController {
     private final TestDatabaseResetService resetService;
+    private final TeamService teamService;
+    private final EventService eventService;
 
     @Value("${app.tenant.test-schema}")
     private String testSchema;
@@ -47,5 +60,101 @@ public class TestController {
                 sourceSchema,
                 testSchema
         ));
+    }
+
+    @Operation(summary = "Create a new team (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "201", description = "Team created successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @PostMapping("/teams")
+    public ResponseEntity<TeamDetailResponse> createTeam(@Valid @RequestBody TeamRequest teamRequest) {
+        log.debug("POST /api/test/teams - Creating team");
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(TeamDetailResponse.from(teamService.createTeam(teamRequest)));
+    }
+
+    @Operation(summary = "Update an existing team (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "200", description = "Team updated successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @ApiResponse(responseCode = "404", description = "Team not found")
+    @ApiResponse(responseCode = "409", description = "Team has associated events")
+    @PutMapping("/teams/{id}")
+    public ResponseEntity<TeamDetailResponse> updateTeam(
+            @Parameter(description = "Team ID") @PathVariable Long id,
+            @Valid @RequestBody TeamRequest teamRequest) {
+        log.debug("PUT /api/test/teams/{} - Updating team", id);
+        return ResponseEntity.ok(TeamDetailResponse.from(teamService.updateTeam(id, teamRequest)));
+    }
+
+    @Operation(summary = "Delete a team (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "204", description = "Team deleted successfully")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @ApiResponse(responseCode = "404", description = "Team not found")
+    @ApiResponse(responseCode = "409", description = "Team has associated events")
+    @DeleteMapping("/teams/{id}")
+    public ResponseEntity<Void> deleteTeam(@Parameter(description = "Team ID") @PathVariable Long id) {
+        log.debug("DELETE /api/test/teams/{} - Deleting team", id);
+        teamService.deleteTeam(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Create a new event (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "201", description = "Event created successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @PostMapping("/events")
+    public ResponseEntity<EventResponse> createEvent(@Valid @RequestBody EventRequest eventRequest) {
+        log.debug("POST /api/test/events - Creating event");
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(EventResponse.from(eventService.createEvent(eventRequest)));
+    }
+
+    @Operation(summary = "Update an existing event (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "200", description = "Event updated successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PutMapping("/events/{id}")
+    public ResponseEntity<EventResponse> updateEvent(
+            @Parameter(description = "Event ID") @PathVariable Long id,
+            @Valid @RequestBody EventRequest eventRequest) {
+        log.debug("PUT /api/test/events/{} - Updating event", id);
+        return ResponseEntity.ok(EventResponse.from(eventService.updateEvent(id, eventRequest)));
+    }
+
+    @Operation(summary = "Delete an event (test database only)",
+            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                    + "Requests without this header will be rejected with 403 Forbidden.",
+            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
+                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @ApiResponse(responseCode = "204", description = "Event deleted successfully")
+    @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @DeleteMapping("/events/{id}")
+    public ResponseEntity<Void> deleteEvent(@Parameter(description = "Event ID") @PathVariable Long id) {
+        log.debug("DELETE /api/test/events/{} - Deleting event", id);
+        eventService.deleteEvent(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -101,6 +101,24 @@ class ControllerIntegrationTests {
         return UUID.randomUUID().toString().substring(0, 3).toUpperCase();
     }
 
+    private String eventJson(int matchNumber) {
+        return """
+                {
+                    "matchNumber": %d,
+                    "stage": "GROUP",
+                    "groupLetter": "A",
+                    "homeTeamId": 1,
+                    "awayTeamId": 2,
+                    "matchDate": "2026-06-11",
+                    "arenaName": "MetLife Stadium",
+                    "city": "New York",
+                    "status": "SCHEDULED",
+                    "hasExtraTime": false,
+                    "hasPenalties": false
+                }
+                """.formatted(matchNumber);
+    }
+
     @Test
     void createTeam_returns201() {
         String code = randomCode();
@@ -108,7 +126,7 @@ class ControllerIntegrationTests {
         String json = teamJson(name, code);
 
         ResponseEntity<TeamDetailResponse> response = restClient.post()
-                .uri("/api/teams")
+                .uri("/api/test/teams")
                 .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(json)
@@ -127,7 +145,7 @@ class ControllerIntegrationTests {
         String createCode = randomCode();
         String createName = "Update Pre " + createCode;
         ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
-                .uri("/api/teams")
+                .uri("/api/test/teams")
                 .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson(createName, createCode))
@@ -139,7 +157,7 @@ class ControllerIntegrationTests {
         String updateCode = randomCode();
         String updateName = "Update Post " + updateCode;
         ResponseEntity<TeamDetailResponse> response = restClient.put()
-                .uri("/api/teams/" + teamId)
+                .uri("/api/test/teams/" + teamId)
                 .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson(updateName, updateCode))
@@ -157,7 +175,7 @@ class ControllerIntegrationTests {
         // First create a team with unique data to delete
         String delCode = randomCode();
         ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
-                .uri("/api/teams")
+                .uri("/api/test/teams")
                 .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson("Delete Test " + delCode, delCode))
@@ -167,7 +185,7 @@ class ControllerIntegrationTests {
         Long teamId = createResponse.getBody().id();
 
         ResponseEntity<Void> response = restClient.delete()
-                .uri("/api/teams/" + teamId)
+                .uri("/api/test/teams/" + teamId)
                 .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .retrieve()
                 .toBodilessEntity();
@@ -178,7 +196,7 @@ class ControllerIntegrationTests {
     @Test
     void createTeam_withoutTestHeader_returns403() {
         ResponseEntity<String> response = restClient.post()
-                .uri("/api/teams")
+                .uri("/api/test/teams")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson("Forbidden Country", randomCode()))
                 .retrieve()
@@ -191,7 +209,7 @@ class ControllerIntegrationTests {
     @Test
     void updateTeam_withoutTestHeader_returns403() {
         ResponseEntity<String> response = restClient.put()
-                .uri("/api/teams/1")
+                .uri("/api/test/teams/1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson("Forbidden Update", randomCode()))
                 .retrieve()
@@ -204,7 +222,107 @@ class ControllerIntegrationTests {
     @Test
     void deleteTeam_withoutTestHeader_returns403() {
         ResponseEntity<String> response = restClient.delete()
-                .uri("/api/teams/1")
+                .uri("/api/test/teams/1")
+                .retrieve()
+                .onStatus(status -> status.value() == 403, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    // Event CUD
+
+    @Test
+    void createEvent_returns201() {
+        ResponseEntity<EventResponse> response = restClient.post()
+                .uri("/api/test/events")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(eventJson(5001))
+                .retrieve()
+                .toEntity(EventResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().matchNumber()).isEqualTo(5001);
+    }
+
+    @Test
+    void updateEvent_returns200() {
+        ResponseEntity<EventResponse> createResponse = restClient.post()
+                .uri("/api/test/events")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(eventJson(5002))
+                .retrieve()
+                .toEntity(EventResponse.class);
+
+        Long eventId = createResponse.getBody().id();
+
+        ResponseEntity<EventResponse> response = restClient.put()
+                .uri("/api/test/events/" + eventId)
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(eventJson(5003))
+                .retrieve()
+                .toEntity(EventResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().matchNumber()).isEqualTo(5003);
+    }
+
+    @Test
+    void deleteEvent_returns204() {
+        ResponseEntity<EventResponse> createResponse = restClient.post()
+                .uri("/api/test/events")
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(eventJson(5004))
+                .retrieve()
+                .toEntity(EventResponse.class);
+
+        Long eventId = createResponse.getBody().id();
+
+        ResponseEntity<Void> response = restClient.delete()
+                .uri("/api/test/events/" + eventId)
+                .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
+                .retrieve()
+                .toBodilessEntity();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    void createEvent_withoutTestHeader_returns403() {
+        ResponseEntity<String> response = restClient.post()
+                .uri("/api/test/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(eventJson(5005))
+                .retrieve()
+                .onStatus(status -> status.value() == 403, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void updateEvent_withoutTestHeader_returns403() {
+        ResponseEntity<String> response = restClient.put()
+                .uri("/api/test/events/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(eventJson(5006))
+                .retrieve()
+                .onStatus(status -> status.value() == 403, (req, res) -> {})
+                .toEntity(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void deleteEvent_withoutTestHeader_returns403() {
+        ResponseEntity<String> response = restClient.delete()
+                .uri("/api/test/events/1")
                 .retrieve()
                 .onStatus(status -> status.value() == 403, (req, res) -> {})
                 .toEntity(String.class);
@@ -269,7 +387,7 @@ class ControllerIntegrationTests {
 
         // Insert a custom team into test schema.
         ResponseEntity<TeamDetailResponse> createResponse = restClient.post()
-                .uri("/api/teams")
+                .uri("/api/test/teams")
                 .header(ApiHeaders.TEST_HEADER, ApiHeaders.TEST_HEADER_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(teamJson(name, code))

--- a/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/EventControllerTests.java
@@ -1,6 +1,5 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.dto.request.EventRequest;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
@@ -25,8 +24,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -192,79 +189,4 @@ class EventControllerTests {
                 .hasMessageContaining("99");
     }
 
-    // CUD helpers
-
-    private EventRequest validEventRequest() {
-        return new EventRequest(1, Stage.GROUP, Group.A,
-                1L, 2L, null, null,
-                LocalDate.of(2026, 6, 11), null, null,
-                "MetLife Stadium", "New York",
-                MatchStatus.SCHEDULED, null, null, null, null, false, false);
-    }
-
-    // createEvent
-
-    @Test
-    void createEvent_returns201WithBody() {
-        EventRequest request = validEventRequest();
-        when(eventService.createEvent(any(EventRequest.class))).thenReturn(event);
-
-        ResponseEntity<EventResponse> response = eventController.createEvent(request);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().id()).isEqualTo(1L);
-        assertThat(response.getBody().matchNumber()).isEqualTo(1);
-        verify(eventService, times(1)).createEvent(any(EventRequest.class));
-    }
-
-    // updateEvent
-
-    @Test
-    void updateEvent_returns200WithBody() {
-        EventRequest request = validEventRequest();
-        when(eventService.updateEvent(eq(1L), any(EventRequest.class))).thenReturn(event);
-
-        ResponseEntity<EventResponse> response = eventController.updateEvent(1L, request);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().id()).isEqualTo(1L);
-        assertThat(response.getBody().matchNumber()).isEqualTo(1);
-        verify(eventService, times(1)).updateEvent(eq(1L), any(EventRequest.class));
-    }
-
-    @Test
-    void updateEvent_throwsEntityNotFoundException_whenNotFound() {
-        EventRequest request = validEventRequest();
-        when(eventService.updateEvent(eq(99L), any(EventRequest.class)))
-                .thenThrow(new EntityNotFoundException("Event not found with id: 99"));
-
-        assertThatThrownBy(() -> eventController.updateEvent(99L, request))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("99");
-    }
-
-    // deleteEvent
-
-    @Test
-    void deleteEvent_returns204() {
-        doNothing().when(eventService).deleteEvent(1L);
-
-        ResponseEntity<Void> response = eventController.deleteEvent(1L);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        assertThat(response.getBody()).isNull();
-        verify(eventService, times(1)).deleteEvent(1L);
-    }
-
-    @Test
-    void deleteEvent_throwsEntityNotFoundException_whenNotFound() {
-        doThrow(new EntityNotFoundException("Event not found with id: 99"))
-                .when(eventService).deleteEvent(99L);
-
-        assertThatThrownBy(() -> eventController.deleteEvent(99L))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("99");
-    }
 }

--- a/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TeamControllerTests.java
@@ -1,11 +1,7 @@
 package com.snodgrass.fifa_api.controller;
 
-import com.snodgrass.fifa_api.dto.request.PlayerRequest;
-import com.snodgrass.fifa_api.dto.request.TeamRequest;
-import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
-import com.snodgrass.fifa_api.exception.TeamHasEventsException;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.TeamPlayer;
 import com.snodgrass.fifa_api.model.enums.Group;
@@ -25,8 +21,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 
@@ -118,90 +112,4 @@ class TeamControllerTests {
         assertThat(response.getBody()).isEmpty();
     }
 
-    // CUD helpers
-
-    private TeamRequest validTeamRequest() {
-        List<PlayerRequest> squad = List.of(
-                new PlayerRequest("Neymar Jr", 10, "FW", true)
-        );
-        TeamStatsRequest stats = new TeamStatsRequest(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
-        return new TeamRequest("Brazil", "BRA", Group.A,
-                "/flags/bra.png", "/logos/bra.png", 1, "Dorival Júnior", squad, stats);
-    }
-
-    // createTeam
-
-    @Test
-    void createTeam_returns201WithBody() {
-        TeamRequest request = validTeamRequest();
-        when(teamService.createTeam(any(TeamRequest.class))).thenReturn(team);
-
-        ResponseEntity<TeamDetailResponse> response = teamController.createTeam(request);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().id()).isEqualTo(1L);
-        assertThat(response.getBody().countryName()).isEqualTo("Brazil");
-        verify(teamService, times(1)).createTeam(any(TeamRequest.class));
-    }
-
-    // updateTeam
-
-    @Test
-    void updateTeam_returns200WithBody() {
-        TeamRequest request = validTeamRequest();
-        when(teamService.updateTeam(eq(1L), any(TeamRequest.class))).thenReturn(team);
-
-        ResponseEntity<TeamDetailResponse> response = teamController.updateTeam(1L, request);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().id()).isEqualTo(1L);
-        assertThat(response.getBody().countryName()).isEqualTo("Brazil");
-        verify(teamService, times(1)).updateTeam(eq(1L), any(TeamRequest.class));
-    }
-
-    @Test
-    void updateTeam_throwsEntityNotFoundException_whenNotFound() {
-        TeamRequest request = validTeamRequest();
-        when(teamService.updateTeam(eq(99L), any(TeamRequest.class)))
-                .thenThrow(new EntityNotFoundException("Team not found with id: 99"));
-
-        assertThatThrownBy(() -> teamController.updateTeam(99L, request))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("99");
-    }
-
-    // deleteTeam
-
-    @Test
-    void deleteTeam_returns204() {
-        doNothing().when(teamService).deleteTeam(1L);
-
-        ResponseEntity<Void> response = teamController.deleteTeam(1L);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-        assertThat(response.getBody()).isNull();
-        verify(teamService, times(1)).deleteTeam(1L);
-    }
-
-    @Test
-    void deleteTeam_throwsEntityNotFoundException_whenNotFound() {
-        doThrow(new EntityNotFoundException("Team not found with id: 99"))
-                .when(teamService).deleteTeam(99L);
-
-        assertThatThrownBy(() -> teamController.deleteTeam(99L))
-                .isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("99");
-    }
-
-    @Test
-    void deleteTeam_throwsTeamHasEventsException_whenTeamHasEvents() {
-        doThrow(new TeamHasEventsException(1L))
-                .when(teamService).deleteTeam(1L);
-
-        assertThatThrownBy(() -> teamController.deleteTeam(1L))
-                .isInstanceOf(TeamHasEventsException.class)
-                .hasMessageContaining("1");
-    }
 }

--- a/src/test/java/com/snodgrass/fifa_api/controller/TestControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/TestControllerTests.java
@@ -1,8 +1,25 @@
 package com.snodgrass.fifa_api.controller;
 
+import com.snodgrass.fifa_api.dto.request.EventRequest;
+import com.snodgrass.fifa_api.dto.request.PlayerRequest;
+import com.snodgrass.fifa_api.dto.request.TeamRequest;
+import com.snodgrass.fifa_api.dto.request.TeamStatsRequest;
+import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.dto.response.ResetDbResponse;
+import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
+import com.snodgrass.fifa_api.exception.TeamHasEventsException;
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.TeamPlayer;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.ResetMode;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import com.snodgrass.fifa_api.service.EventService;
+import com.snodgrass.fifa_api.service.TeamService;
 import com.snodgrass.fifa_api.service.TestDatabaseResetService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -11,7 +28,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,8 +43,42 @@ class TestControllerTests {
     @Mock
     private TestDatabaseResetService resetService;
 
+    @Mock
+    private TeamService teamService;
+
+    @Mock
+    private EventService eventService;
+
     @InjectMocks
     private TestController testController;
+
+    private Team team;
+    private Event event;
+
+    @BeforeEach
+    void setUp() {
+        team = new Team();
+        team.setId(1L);
+        team.setCountryName("Brazil");
+        team.setCountryCode("BRA");
+        team.setGroupLetter(Group.A);
+        team.setSquad(List.of(new TeamPlayer("Neymar Jr", 10, "FW", true)));
+        team.setCreatedAt(LocalDateTime.now());
+        team.setUpdatedAt(LocalDateTime.now());
+
+        event = new Event();
+        event.setId(1L);
+        event.setMatchNumber(1);
+        event.setStage(Stage.GROUP);
+        event.setGroupLetter(Group.A);
+        event.setHomeTeam(team);
+        event.setArenaName("Lusail Stadium");
+        event.setCity("Lusail");
+        event.setMatchDate(LocalDate.of(2026, 6, 11));
+        event.setStatus(MatchStatus.SCHEDULED);
+        event.setCreatedAt(LocalDateTime.now());
+        event.setUpdatedAt(LocalDateTime.now());
+    }
 
     @Test
     void resetDatabase_template_returns200() {
@@ -46,5 +104,152 @@ class TestControllerTests {
         assertThat(response.getBody().mode()).isEqualTo(ResetMode.PROD_SYNC);
         assertThat(response.getBody().sourceSchema()).isEqualTo("fifa_world_cup");
         verify(resetService, times(1)).resetTestDatabase(ResetMode.PROD_SYNC);
+    }
+
+    private TeamRequest validTeamRequest() {
+        List<PlayerRequest> squad = List.of(
+                new PlayerRequest("Neymar Jr", 10, "FW", true)
+        );
+        TeamStatsRequest stats = new TeamStatsRequest(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
+        return new TeamRequest("Brazil", "BRA", Group.A,
+                "/flags/bra.png", "/logos/bra.png", 1, "Dorival Júnior", squad, stats);
+    }
+
+    private EventRequest validEventRequest() {
+        return new EventRequest(1, Stage.GROUP, Group.A,
+                1L, 2L, null, null,
+                LocalDate.of(2026, 6, 11), null, null,
+                "MetLife Stadium", "New York",
+                MatchStatus.SCHEDULED, null, null, null, null, false, false);
+    }
+
+    @Test
+    void createTeam_returns201WithBody() {
+        TeamRequest request = validTeamRequest();
+        when(teamService.createTeam(any(TeamRequest.class))).thenReturn(team);
+
+        ResponseEntity<TeamDetailResponse> response = testController.createTeam(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().countryName()).isEqualTo("Brazil");
+        verify(teamService, times(1)).createTeam(any(TeamRequest.class));
+    }
+
+    @Test
+    void updateTeam_returns200WithBody() {
+        TeamRequest request = validTeamRequest();
+        when(teamService.updateTeam(eq(1L), any(TeamRequest.class))).thenReturn(team);
+
+        ResponseEntity<TeamDetailResponse> response = testController.updateTeam(1L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().countryName()).isEqualTo("Brazil");
+        verify(teamService, times(1)).updateTeam(eq(1L), any(TeamRequest.class));
+    }
+
+    @Test
+    void updateTeam_throwsEntityNotFoundException_whenNotFound() {
+        TeamRequest request = validTeamRequest();
+        when(teamService.updateTeam(eq(99L), any(TeamRequest.class)))
+                .thenThrow(new EntityNotFoundException("Team not found with id: 99"));
+
+        assertThatThrownBy(() -> testController.updateTeam(99L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void deleteTeam_returns204() {
+        doNothing().when(teamService).deleteTeam(1L);
+
+        ResponseEntity<Void> response = testController.deleteTeam(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+        verify(teamService, times(1)).deleteTeam(1L);
+    }
+
+    @Test
+    void deleteTeam_throwsEntityNotFoundException_whenNotFound() {
+        doThrow(new EntityNotFoundException("Team not found with id: 99"))
+                .when(teamService).deleteTeam(99L);
+
+        assertThatThrownBy(() -> testController.deleteTeam(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void deleteTeam_throwsTeamHasEventsException_whenTeamHasEvents() {
+        doThrow(new TeamHasEventsException(1L))
+                .when(teamService).deleteTeam(1L);
+
+        assertThatThrownBy(() -> testController.deleteTeam(1L))
+                .isInstanceOf(TeamHasEventsException.class)
+                .hasMessageContaining("1");
+    }
+
+    @Test
+    void createEvent_returns201WithBody() {
+        EventRequest request = validEventRequest();
+        when(eventService.createEvent(any(EventRequest.class))).thenReturn(event);
+
+        ResponseEntity<EventResponse> response = testController.createEvent(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().matchNumber()).isEqualTo(1);
+        verify(eventService, times(1)).createEvent(any(EventRequest.class));
+    }
+
+    @Test
+    void updateEvent_returns200WithBody() {
+        EventRequest request = validEventRequest();
+        when(eventService.updateEvent(eq(1L), any(EventRequest.class))).thenReturn(event);
+
+        ResponseEntity<EventResponse> response = testController.updateEvent(1L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(1L);
+        assertThat(response.getBody().matchNumber()).isEqualTo(1);
+        verify(eventService, times(1)).updateEvent(eq(1L), any(EventRequest.class));
+    }
+
+    @Test
+    void updateEvent_throwsEntityNotFoundException_whenNotFound() {
+        EventRequest request = validEventRequest();
+        when(eventService.updateEvent(eq(99L), any(EventRequest.class)))
+                .thenThrow(new EntityNotFoundException("Event not found with id: 99"));
+
+        assertThatThrownBy(() -> testController.updateEvent(99L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void deleteEvent_returns204() {
+        doNothing().when(eventService).deleteEvent(1L);
+
+        ResponseEntity<Void> response = testController.deleteEvent(1L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+        verify(eventService, times(1)).deleteEvent(1L);
+    }
+
+    @Test
+    void deleteEvent_throwsEntityNotFoundException_whenNotFound() {
+        doThrow(new EntityNotFoundException("Event not found with id: 99"))
+                .when(eventService).deleteEvent(99L);
+
+        assertThatThrownBy(() -> testController.deleteEvent(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("99");
     }
 }


### PR DESCRIPTION
- Moved mutable endpoints from both the `TeamController` and `EventController` over the `TestController`
    - This makes more sense from an consumer perspective and makes the swagger documentation easier to follow and read
- Updated tests
- closes #21 