### PR TITLE
Add Schedule Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ http://localhost:8080/v3/api-docs
 | GET | `/api/events/status/{status}` | Get events by status |
 | GET | `/api/events/team/{teamId}` | Get all events involving a team |
 
+### Schedule
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/schedule?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD` | Get grouped schedule cards by inclusive date range |
+
 ### Test
 
 | Method | Endpoint | Description |

--- a/src/main/java/com/snodgrass/fifa_api/controller/ScheduleController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/ScheduleController.java
@@ -1,0 +1,46 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.dto.response.ScheduleResponse;
+import com.snodgrass.fifa_api.service.EventService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/schedule")
+@RequiredArgsConstructor
+@Tag(name = "Schedule", description = "Endpoints for retrieving schedule-focused event summaries")
+public class ScheduleController {
+    private final EventService eventService;
+
+    @Operation(summary = "Get schedule by date range",
+            description = "Returns events grouped by date with a lightweight event payload for schedule pages.")
+    @ApiResponse(responseCode = "200", description = "Schedule returned successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid or malformed date range")
+    @GetMapping
+    public ResponseEntity<List<ScheduleResponse>> getSchedule(
+            @Parameter(description = "Start date (inclusive), format: YYYY-MM-DD")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "End date (inclusive), format: YYYY-MM-DD")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("startDate must be before or equal to endDate");
+        }
+
+        log.debug("GET /api/schedule?startDate={}&endDate={} - Fetching grouped schedule", startDate, endDate);
+        return ResponseEntity.ok(eventService.getSchedule(startDate, endDate));
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/ScheduleEventResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/ScheduleEventResponse.java
@@ -1,0 +1,39 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+
+public record ScheduleEventResponse(
+        Long eventId,
+        String arenaName,
+        MatchStatus status,
+        Integer homeScore,
+        Integer awayScore,
+        String awayTeamName,
+        String awayTeamFlagUrl,
+        String homeTeamName,
+        String homeTeamFlagUrl
+) {
+    public static ScheduleEventResponse from(Event event) {
+        Team homeTeam = event.getHomeTeam();
+        Team awayTeam = event.getAwayTeam();
+
+        String homeName = homeTeam != null ? homeTeam.getCountryName() : event.getHomeTeamPlaceholder();
+        String awayName = awayTeam != null ? awayTeam.getCountryName() : event.getAwayTeamPlaceholder();
+        String homeFlag = homeTeam != null ? homeTeam.getFlagUrl() : null;
+        String awayFlag = awayTeam != null ? awayTeam.getFlagUrl() : null;
+
+        return new ScheduleEventResponse(
+                event.getId(),
+                event.getArenaName(),
+                event.getStatus(),
+                event.getHomeScore(),
+                event.getAwayScore(),
+                awayName,
+                awayFlag,
+                homeName,
+                homeFlag
+        );
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/ScheduleResponse.java
@@ -1,0 +1,9 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ScheduleResponse(
+        LocalDate date,
+        List<ScheduleEventResponse> scheduledEvents
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/snodgrass/fifa_api/exception/GlobalExceptionHandler.java
@@ -40,6 +40,13 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(400, "Invalid value for parameter: " + ex.getName(), LocalDateTime.now()));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, ex.getMessage(), LocalDateTime.now()));
+    }
+
     @ExceptionHandler(DatabaseResetException.class)
     public ResponseEntity<ErrorResponse> handleDatabaseResetException(DatabaseResetException ex) {
         return ResponseEntity

--- a/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
+++ b/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
@@ -7,6 +7,7 @@ import com.snodgrass.fifa_api.model.enums.MatchStatus;
 import com.snodgrass.fifa_api.model.enums.Stage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
@@ -14,5 +15,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByStage(Stage stage);
     List<Event> findByStatus(MatchStatus status);
     List<Event> findByHomeTeamOrAwayTeam(Team homeTeam, Team awayTeam);
+    List<Event> findByMatchDateBetweenOrderByMatchDateAscKickoffTimeAsc(LocalDate startDate, LocalDate endDate);
     boolean existsByHomeTeamOrAwayTeam(Team homeTeam, Team awayTeam);
 }

--- a/src/main/java/com/snodgrass/fifa_api/service/EventService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/EventService.java
@@ -1,6 +1,8 @@
 package com.snodgrass.fifa_api.service;
 
 import com.snodgrass.fifa_api.dto.request.EventRequest;
+import com.snodgrass.fifa_api.dto.response.ScheduleEventResponse;
+import com.snodgrass.fifa_api.dto.response.ScheduleResponse;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
@@ -12,7 +14,13 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +51,22 @@ public class EventService {
 
     public List<Event> getEventsByTeam(Team team) {
         return eventRepository.findByHomeTeamOrAwayTeam(team, team);
+    }
+
+    public List<ScheduleResponse> getSchedule(LocalDate startDate, LocalDate endDate) {
+        List<Event> events = eventRepository.findByMatchDateBetweenOrderByMatchDateAscKickoffTimeAsc(startDate, endDate);
+        Map<LocalDate, List<Event>> grouped = events.stream().collect(groupingBy(
+                Event::getMatchDate,
+                LinkedHashMap::new,
+                Collectors.toList()
+        ));
+
+        return grouped.entrySet().stream()
+                .map(entry -> new ScheduleResponse(
+                        entry.getKey(),
+                        entry.getValue().stream().map(ScheduleEventResponse::from).toList()
+                ))
+                .toList();
     }
 
     public Event createEvent(EventRequest request) {

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -2,6 +2,7 @@ package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.config.ApiHeaders;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
+import com.snodgrass.fifa_api.dto.response.ScheduleResponse;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
 import com.snodgrass.fifa_api.exception.ErrorResponse;
@@ -80,6 +81,42 @@ class ControllerIntegrationTests {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().message()).contains("999999");
+    }
+
+    // Schedule
+    @Test
+    void getSchedule_returns200WithNonEmptyList() {
+        ResponseEntity<List<ScheduleResponse>> response = restClient.get()
+                .uri("/api/schedule?startDate=2000-01-01&endDate=2100-12-31")
+                .retrieve()
+                .toEntity(new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().getFirst().scheduledEvents()).isNotEmpty();
+        assertThat(response.getBody().getFirst().scheduledEvents().getFirst().eventId()).isNotNull();
+    }
+
+    @Test
+    void getSchedule_returns400_whenRangeInvalid() {
+        ResponseEntity<ErrorResponse> response = restClient.get()
+                .uri("/api/schedule?startDate=2026-06-12&endDate=2026-06-11")
+                .retrieve()
+                .onStatus(status -> status.value() == 400, (req, res) -> {})
+                .toEntity(ErrorResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void getSchedule_returns400_whenDateMalformed() {
+        ResponseEntity<ErrorResponse> response = restClient.get()
+                .uri("/api/schedule?startDate=bad-date&endDate=2026-06-11")
+                .retrieve()
+                .onStatus(status -> status.value() == 400, (req, res) -> {})
+                .toEntity(ErrorResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     // Team CUD

--- a/src/test/java/com/snodgrass/fifa_api/controller/ScheduleControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ScheduleControllerTests.java
@@ -1,0 +1,61 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.dto.response.ScheduleEventResponse;
+import com.snodgrass.fifa_api.dto.response.ScheduleResponse;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.service.EventService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleControllerTests {
+    @Mock
+    private EventService eventService;
+
+    @InjectMocks
+    private ScheduleController scheduleController;
+
+    @Test
+    void getSchedule_returns200_whenRangeValid() {
+        LocalDate start = LocalDate.of(2026, 6, 11);
+        LocalDate end = LocalDate.of(2026, 6, 12);
+        List<ScheduleResponse> payload = List.of(
+                new ScheduleResponse(
+                        start,
+                        List.of(new ScheduleEventResponse(1L, "Arena", MatchStatus.SCHEDULED, null, null,
+                                "Away", "/flags/away.png", "Home", "/flags/home.png"))
+                )
+        );
+        when(eventService.getSchedule(start, end)).thenReturn(payload);
+
+        ResponseEntity<List<ScheduleResponse>> response = scheduleController.getSchedule(start, end);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        verify(eventService, times(1)).getSchedule(start, end);
+    }
+
+    @Test
+    void getSchedule_throwsIllegalArgument_whenStartAfterEnd() {
+        LocalDate start = LocalDate.of(2026, 6, 12);
+        LocalDate end = LocalDate.of(2026, 6, 11);
+
+        assertThatThrownBy(() -> scheduleController.getSchedule(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("startDate");
+
+        verify(eventService, never()).getSchedule(any(), any());
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/EventServiceTests.java
@@ -1,6 +1,7 @@
 package com.snodgrass.fifa_api.service;
 
 import com.snodgrass.fifa_api.dto.request.EventRequest;
+import com.snodgrass.fifa_api.dto.response.ScheduleResponse;
 import com.snodgrass.fifa_api.model.Event;
 import com.snodgrass.fifa_api.model.Team;
 import com.snodgrass.fifa_api.model.enums.Group;
@@ -325,5 +326,69 @@ class EventServiceTests {
                 .hasMessageContaining("99");
 
         verify(eventRepository, never()).delete(any(Event.class));
+    }
+
+    @Test
+    void getSchedule_groupsByDateAndMapsFields() {
+        Team home = createTeam(1L, "Brazil");
+        home.setFlagUrl("/flags/bra.png");
+        Team away = createTeam(2L, "Argentina");
+        away.setFlagUrl("/flags/arg.png");
+
+        Event e1 = new Event();
+        e1.setId(1L);
+        e1.setMatchDate(LocalDate.of(2026, 6, 11));
+        e1.setArenaName("MetLife");
+        e1.setStatus(MatchStatus.SCHEDULED);
+        e1.setHomeTeam(home);
+        e1.setAwayTeam(away);
+
+        Event e2 = new Event();
+        e2.setId(2L);
+        e2.setMatchDate(LocalDate.of(2026, 6, 11));
+        e2.setArenaName("AT&T");
+        e2.setStatus(MatchStatus.FINISHED);
+        e2.setHomeTeam(home);
+        e2.setAwayTeam(away);
+        e2.setHomeScore(2);
+        e2.setAwayScore(1);
+
+        when(eventRepository.findByMatchDateBetweenOrderByMatchDateAscKickoffTimeAsc(
+                LocalDate.of(2026, 6, 11), LocalDate.of(2026, 6, 12)
+        )).thenReturn(List.of(e1, e2));
+
+        List<ScheduleResponse> result = eventService.getSchedule(
+                LocalDate.of(2026, 6, 11), LocalDate.of(2026, 6, 12)
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().date()).isEqualTo(LocalDate.of(2026, 6, 11));
+        assertThat(result.getFirst().scheduledEvents()).hasSize(2);
+        assertThat(result.getFirst().scheduledEvents().getFirst().eventId()).isEqualTo(1L);
+        assertThat(result.getFirst().scheduledEvents().get(1).homeScore()).isEqualTo(2);
+    }
+
+    @Test
+    void getSchedule_usesPlaceholdersWhenTeamsMissing() {
+        Event e = new Event();
+        e.setId(3L);
+        e.setMatchDate(LocalDate.of(2026, 6, 13));
+        e.setArenaName("Arena");
+        e.setStatus(MatchStatus.SCHEDULED);
+        e.setHomeTeamPlaceholder("Winner A");
+        e.setAwayTeamPlaceholder("Runner-up B");
+
+        when(eventRepository.findByMatchDateBetweenOrderByMatchDateAscKickoffTimeAsc(
+                LocalDate.of(2026, 6, 13), LocalDate.of(2026, 6, 13)
+        )).thenReturn(List.of(e));
+
+        List<ScheduleResponse> result = eventService.getSchedule(
+                LocalDate.of(2026, 6, 13), LocalDate.of(2026, 6, 13)
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().scheduledEvents()).hasSize(1);
+        assertThat(result.getFirst().scheduledEvents().getFirst().homeTeamName()).isEqualTo("Winner A");
+        assertThat(result.getFirst().scheduledEvents().getFirst().awayTeamName()).isEqualTo("Runner-up B");
     }
 }


### PR DESCRIPTION
- Added a new read endpoint at `/api/schedule` that accepts `startDate` and `endDate` query params (inclusive)
- Added `ScheduleResponse` to represent a date and list of `ScheduledEvent`
- Added `ScheduledEvent` that holds a lightweight version of `Event`
- Added a JPA formatted (cursed) endpoint to get events based on a date range: `findByMatchDateBetweenOrderByMatchDateAscKickoffTimeAsc`
- Added `ScheduleController` to handle the endpoint and for validation
- Updated `GlobalExceptionHandler` to handle 400 for `IllegalArgumentException`
- Added appropriate tests
- Updated README
- closes #23 