### PR TITLE
Create Standings Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ http://localhost:8080/v3/api-docs
 |--------|----------|-------------|
 | GET | `/api/schedule?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD` | Get grouped schedule cards by inclusive date range |
 
+### Standings
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/standings/group` | Get group standings by group letter with team stats |
+| GET | `/api/standings/bracket` | Get round-based knockout bracket data for bracket UI views |
+
 ### Test
 
 | Method | Endpoint | Description |

--- a/src/main/java/com/snodgrass/fifa_api/controller/StandingsController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/StandingsController.java
@@ -1,0 +1,41 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.dto.response.BracketStandingsResponse;
+import com.snodgrass.fifa_api.dto.response.GroupStandingsResponse;
+import com.snodgrass.fifa_api.service.StandingsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/standings")
+@RequiredArgsConstructor
+@Tag(name = "Standings", description = "Endpoints for group standings and knockout bracket views")
+public class StandingsController {
+    private final StandingsService standingsService;
+
+    @Operation(summary = "Get group stage standings")
+    @ApiResponse(responseCode = "200", description = "Group standings returned successfully")
+    @GetMapping("/group")
+    public ResponseEntity<List<GroupStandingsResponse>> getGroupStandings() {
+        log.debug("GET /api/standings/group - Fetching grouped standings");
+        return ResponseEntity.ok(standingsService.getGroupStandings());
+    }
+
+    @Operation(summary = "Get knockout bracket standings")
+    @ApiResponse(responseCode = "200", description = "Bracket standings returned successfully")
+    @GetMapping("/bracket")
+    public ResponseEntity<BracketStandingsResponse> getBracketStandings() {
+        log.debug("GET /api/standings/bracket - Fetching bracket standings");
+        return ResponseEntity.ok(standingsService.getBracketStandings());
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/BracketMatchResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/BracketMatchResponse.java
@@ -1,0 +1,50 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record BracketMatchResponse(
+        Long eventId,
+        Integer matchNumber,
+        LocalDate matchDate,
+        LocalTime kickoffTime,
+        MatchStatus status,
+        String arenaName,
+        String city,
+        String homeTeamName,
+        String homeTeamFlagUrl,
+        String awayTeamName,
+        String awayTeamFlagUrl,
+        Integer homeScore,
+        Integer awayScore,
+        Long winnerTeamId,
+        String winnerTeamName
+) {
+    public static BracketMatchResponse from(Event event) {
+        Team homeTeam = event.getHomeTeam();
+        Team awayTeam = event.getAwayTeam();
+        Team winner = event.getWinnerTeam();
+
+        return new BracketMatchResponse(
+                event.getId(),
+                event.getMatchNumber(),
+                event.getMatchDate(),
+                event.getKickoffTime(),
+                event.getStatus(),
+                event.getArenaName(),
+                event.getCity(),
+                homeTeam != null ? homeTeam.getCountryName() : event.getHomeTeamPlaceholder(),
+                homeTeam != null ? homeTeam.getFlagUrl() : null,
+                awayTeam != null ? awayTeam.getCountryName() : event.getAwayTeamPlaceholder(),
+                awayTeam != null ? awayTeam.getFlagUrl() : null,
+                event.getHomeScore(),
+                event.getAwayScore(),
+                winner != null ? winner.getId() : null,
+                winner != null ? winner.getCountryName() : null
+        );
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/BracketStandingsResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/BracketStandingsResponse.java
@@ -1,0 +1,14 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record BracketStandingsResponse(
+        List<BracketMatchResponse> roundOf32,
+        List<BracketMatchResponse> roundOf16,
+        List<BracketMatchResponse> quarterfinal,
+        List<BracketMatchResponse> semifinal,
+        List<BracketMatchResponse> thirdPlace,
+        @JsonProperty("final") List<BracketMatchResponse> finalStage
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/GroupStandingsResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/GroupStandingsResponse.java
@@ -1,0 +1,10 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import com.snodgrass.fifa_api.model.enums.Group;
+
+import java.util.List;
+
+public record GroupStandingsResponse(
+        Group groupLetter,
+        List<GroupStandingsTeamResponse> teams
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/GroupStandingsTeamResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/GroupStandingsTeamResponse.java
@@ -1,0 +1,23 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import com.snodgrass.fifa_api.model.Team;
+
+public record GroupStandingsTeamResponse(
+        Long teamId,
+        String countryName,
+        String countryCode,
+        String flagUrl,
+        Integer fifaRanking,
+        TeamStatsResponse stats
+) {
+    public static GroupStandingsTeamResponse from(Team team) {
+        return new GroupStandingsTeamResponse(
+                team.getId(),
+                team.getCountryName(),
+                team.getCountryCode(),
+                team.getFlagUrl(),
+                team.getFifaRanking(),
+                TeamStatsResponse.from(team.getStats())
+        );
+    }
+}

--- a/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
+++ b/src/main/java/com/snodgrass/fifa_api/repository/EventRepository.java
@@ -16,5 +16,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByStatus(MatchStatus status);
     List<Event> findByHomeTeamOrAwayTeam(Team homeTeam, Team awayTeam);
     List<Event> findByMatchDateBetweenOrderByMatchDateAscKickoffTimeAsc(LocalDate startDate, LocalDate endDate);
+    List<Event> findByStageInOrderByMatchNumberAsc(List<Stage> stages);
     boolean existsByHomeTeamOrAwayTeam(Team homeTeam, Team awayTeam);
 }

--- a/src/main/java/com/snodgrass/fifa_api/service/StandingsService.java
+++ b/src/main/java/com/snodgrass/fifa_api/service/StandingsService.java
@@ -1,0 +1,85 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.dto.response.BracketMatchResponse;
+import com.snodgrass.fifa_api.dto.response.BracketStandingsResponse;
+import com.snodgrass.fifa_api.dto.response.GroupStandingsResponse;
+import com.snodgrass.fifa_api.dto.response.GroupStandingsTeamResponse;
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.TeamStats;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import com.snodgrass.fifa_api.repository.EventRepository;
+import com.snodgrass.fifa_api.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class StandingsService {
+    private final TeamRepository teamRepository;
+    private final EventRepository eventRepository;
+
+    public List<GroupStandingsResponse> getGroupStandings() {
+        List<Team> teams = teamRepository.findAll();
+        Map<Group, List<Team>> grouped = teams.stream()
+                .collect(Collectors.groupingBy(Team::getGroupLetter));
+
+        Comparator<Team> standingsComparator = Comparator
+                .comparingInt((Team t) -> safeStats(t).getGroupPoints()).reversed()
+                .thenComparingInt((Team t) -> safeStats(t).getGoalDifference()).reversed()
+                .thenComparingInt((Team t) -> safeStats(t).getGoalsFor()).reversed()
+                .thenComparing(Team::getFifaRanking, Comparator.nullsLast(Integer::compareTo))
+                .thenComparing(Team::getCountryName, Comparator.nullsLast(String::compareTo));
+
+        return Stream.of(Group.values())
+                .map(group -> new GroupStandingsResponse(
+                        group,
+                        grouped.getOrDefault(group, List.of()).stream()
+                                .sorted(standingsComparator)
+                                .map(GroupStandingsTeamResponse::from)
+                                .toList()
+                ))
+                .toList();
+    }
+
+    public BracketStandingsResponse getBracketStandings() {
+        List<Event> knockoutEvents = eventRepository.findByStageInOrderByMatchNumberAsc(List.of(
+                Stage.ROUND_OF_32,
+                Stage.ROUND_OF_16,
+                Stage.QUARTERFINAL,
+                Stage.SEMIFINAL,
+                Stage.THIRD_PLACE,
+                Stage.FINAL
+        ));
+
+        Map<Stage, List<BracketMatchResponse>> byStage = knockoutEvents.stream()
+                .collect(Collectors.groupingBy(
+                        Event::getStage,
+                        Collectors.mapping(BracketMatchResponse::from, Collectors.toList())
+                ));
+
+        return new BracketStandingsResponse(
+                byStage.getOrDefault(Stage.ROUND_OF_32, List.of()),
+                byStage.getOrDefault(Stage.ROUND_OF_16, List.of()),
+                byStage.getOrDefault(Stage.QUARTERFINAL, List.of()),
+                byStage.getOrDefault(Stage.SEMIFINAL, List.of()),
+                byStage.getOrDefault(Stage.THIRD_PLACE, List.of()),
+                byStage.getOrDefault(Stage.FINAL, List.of())
+        );
+    }
+
+    private TeamStats safeStats(Team team) {
+        TeamStats stats = team.getStats();
+        if (stats != null) {
+            return stats;
+        }
+        return new TeamStats();
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/ControllerIntegrationTests.java
@@ -1,7 +1,9 @@
 package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.config.ApiHeaders;
+import com.snodgrass.fifa_api.dto.response.BracketStandingsResponse;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
+import com.snodgrass.fifa_api.dto.response.GroupStandingsResponse;
 import com.snodgrass.fifa_api.dto.response.ScheduleResponse;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.dto.response.TeamResponse;
@@ -117,6 +119,32 @@ class ControllerIntegrationTests {
                 .toEntity(ErrorResponse.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    // Standings
+    @Test
+    void getGroupStandings_returns200WithGroups() {
+        ResponseEntity<List<GroupStandingsResponse>> response = restClient.get()
+                .uri("/api/standings/group")
+                .retrieve()
+                .toEntity(new ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotEmpty();
+        assertThat(response.getBody().getFirst().groupLetter()).isNotNull();
+    }
+
+    @Test
+    void getBracketStandings_returns200WithRounds() {
+        ResponseEntity<BracketStandingsResponse> response = restClient.get()
+                .uri("/api/standings/bracket")
+                .retrieve()
+                .toEntity(BracketStandingsResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().roundOf32()).isNotNull();
+        assertThat(response.getBody().finalStage()).isNotNull();
     }
 
     // Team CUD

--- a/src/test/java/com/snodgrass/fifa_api/controller/StandingsControllerTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/controller/StandingsControllerTests.java
@@ -1,0 +1,53 @@
+package com.snodgrass.fifa_api.controller;
+
+import com.snodgrass.fifa_api.dto.response.BracketStandingsResponse;
+import com.snodgrass.fifa_api.dto.response.GroupStandingsResponse;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.service.StandingsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StandingsControllerTests {
+    @Mock
+    private StandingsService standingsService;
+
+    @InjectMocks
+    private StandingsController standingsController;
+
+    @Test
+    void getGroupStandings_returns200() {
+        when(standingsService.getGroupStandings()).thenReturn(List.of(
+                new GroupStandingsResponse(Group.A, List.of())
+        ));
+
+        ResponseEntity<List<GroupStandingsResponse>> response = standingsController.getGroupStandings();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        verify(standingsService, times(1)).getGroupStandings();
+    }
+
+    @Test
+    void getBracketStandings_returns200() {
+        when(standingsService.getBracketStandings()).thenReturn(new BracketStandingsResponse(
+                List.of(), List.of(), List.of(), List.of(), List.of(), List.of()
+        ));
+
+        ResponseEntity<BracketStandingsResponse> response = standingsController.getBracketStandings();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        verify(standingsService, times(1)).getBracketStandings();
+    }
+}

--- a/src/test/java/com/snodgrass/fifa_api/service/StandingsServiceTests.java
+++ b/src/test/java/com/snodgrass/fifa_api/service/StandingsServiceTests.java
@@ -1,0 +1,121 @@
+package com.snodgrass.fifa_api.service;
+
+import com.snodgrass.fifa_api.dto.response.BracketStandingsResponse;
+import com.snodgrass.fifa_api.dto.response.GroupStandingsResponse;
+import com.snodgrass.fifa_api.model.Event;
+import com.snodgrass.fifa_api.model.Team;
+import com.snodgrass.fifa_api.model.TeamStats;
+import com.snodgrass.fifa_api.model.enums.Group;
+import com.snodgrass.fifa_api.model.enums.MatchStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import com.snodgrass.fifa_api.repository.EventRepository;
+import com.snodgrass.fifa_api.repository.TeamRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StandingsServiceTests {
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private StandingsService standingsService;
+
+    @Test
+    void getGroupStandings_sortsByStatsThenFifaRankingFallback() {
+        Team a = createTeam(1L, "Alpha", Group.A, 9, 1, 2, 5);
+        Team b = createTeam(2L, "Beta", Group.A, 4, 1, 2, 10);
+        Team c = createTeam(3L, "Gamma", Group.A, 4, 1, 2, 30);
+
+        when(teamRepository.findAll()).thenReturn(List.of(c, a, b));
+
+        List<GroupStandingsResponse> result = standingsService.getGroupStandings();
+
+        GroupStandingsResponse groupA = result.stream()
+                .filter(g -> g.groupLetter() == Group.A)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(groupA.teams()).hasSize(3);
+        assertThat(groupA.teams().getFirst().countryName()).isEqualTo("Alpha");
+        assertThat(groupA.teams().get(1).countryName()).isEqualTo("Beta");
+        assertThat(groupA.teams().get(2).countryName()).isEqualTo("Gamma");
+    }
+
+    @Test
+    void getGroupStandings_returnsGroupsInAlphabeticalOrder() {
+        when(teamRepository.findAll()).thenReturn(List.of(
+                createTeam(1L, "Team L", Group.L, 1, 0, 0, 10),
+                createTeam(2L, "Team A", Group.A, 1, 0, 0, 20)
+        ));
+
+        List<GroupStandingsResponse> result = standingsService.getGroupStandings();
+
+        assertThat(result).hasSize(12);
+        assertThat(result.getFirst().groupLetter()).isEqualTo(Group.A);
+        assertThat(result.getLast().groupLetter()).isEqualTo(Group.L);
+    }
+
+    @Test
+    void getBracketStandings_partitionsByRoundAndUsesPlaceholders() {
+        Event r32 = createEvent(101L, 73, Stage.ROUND_OF_32, null, null, "1st Group A", "2nd Group B");
+        Event finalMatch = createEvent(201L, 104, Stage.FINAL, null, null, "Winner SF-101", "Winner SF-102");
+        when(eventRepository.findByStageInOrderByMatchNumberAsc(List.of(
+                Stage.ROUND_OF_32,
+                Stage.ROUND_OF_16,
+                Stage.QUARTERFINAL,
+                Stage.SEMIFINAL,
+                Stage.THIRD_PLACE,
+                Stage.FINAL
+        ))).thenReturn(List.of(r32, finalMatch));
+
+        BracketStandingsResponse response = standingsService.getBracketStandings();
+
+        assertThat(response.roundOf32()).hasSize(1);
+        assertThat(response.finalStage()).hasSize(1);
+        assertThat(response.roundOf32().getFirst().homeTeamName()).isEqualTo("1st Group A");
+        assertThat(response.finalStage().getFirst().awayTeamName()).isEqualTo("Winner SF-102");
+    }
+
+    private Team createTeam(Long id, String name, Group group, int points, int gd, int gf, Integer fifaRanking) {
+        Team team = new Team();
+        team.setId(id);
+        team.setCountryName(name);
+        team.setCountryCode(name.substring(0, Math.min(3, name.length())).toUpperCase());
+        team.setGroupLetter(group);
+        team.setFifaRanking(fifaRanking);
+
+        TeamStats stats = new TeamStats();
+        stats.setGroupPoints(points);
+        stats.setGoalDifference(gd);
+        stats.setGoalsFor(gf);
+        team.setStats(stats);
+        return team;
+    }
+
+    private Event createEvent(Long id, int matchNumber, Stage stage, Team home, Team away, String homePlaceholder, String awayPlaceholder) {
+        Event e = new Event();
+        e.setId(id);
+        e.setMatchNumber(matchNumber);
+        e.setStage(stage);
+        e.setStatus(MatchStatus.SCHEDULED);
+        e.setArenaName("Arena");
+        e.setCity("City");
+        e.setHomeTeam(home);
+        e.setAwayTeam(away);
+        e.setHomeTeamPlaceholder(homePlaceholder);
+        e.setAwayTeamPlaceholder(awayPlaceholder);
+        return e;
+    }
+}


### PR DESCRIPTION
- Added new standings endpoints for both Group Stage and Knockout Stage
    - `/api/standings/group`
    - `/api/standings/bracket`
- Implemented group standings response models to return group letter plus ordered team rows with team stats
- Implemented bracket response models to return round-based knockout data: `roundOf32`, `roundOf16`, `quarterfinal`, `semifinal`, `thirdPlace`, and `final`
- Added `StandingsService` to centralize standings mapping and sorting logic for both group and bracket endpoints
- Implemented group sorting tie-breakers: `groupPoints` desc, `goalDifference` desc, `goalsFor` desc, `fifaRanking` asc (fallback), and `countryName` asc
- Added repository support for ordered knockout-stage events `findByStageInOrderByMatchNumberAsc`
- Added tests
- closes #25 