### PR TITLE
Add Simulation Endpoint Skeleton

### DIFF
--- a/src/main/java/com/snodgrass/fifa_api/controller/ScheduleController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/ScheduleController.java
@@ -27,7 +27,7 @@ public class ScheduleController {
     private final EventService eventService;
 
     @Operation(summary = "Get schedule by date range",
-            description = "Returns events grouped by date with a lightweight event payload for schedule pages.")
+        description = "Returns events grouped by date with a lightweight event payload for schedule pages.")
     @ApiResponse(responseCode = "200", description = "Schedule returned successfully")
     @ApiResponse(responseCode = "400", description = "Invalid or malformed date range")
     @GetMapping

--- a/src/main/java/com/snodgrass/fifa_api/controller/TestController.java
+++ b/src/main/java/com/snodgrass/fifa_api/controller/TestController.java
@@ -2,9 +2,11 @@ package com.snodgrass.fifa_api.controller;
 
 import com.snodgrass.fifa_api.config.ApiHeaders;
 import com.snodgrass.fifa_api.dto.request.EventRequest;
+import com.snodgrass.fifa_api.dto.request.SimulationRequest;
 import com.snodgrass.fifa_api.dto.request.TeamRequest;
 import com.snodgrass.fifa_api.dto.response.EventResponse;
 import com.snodgrass.fifa_api.dto.response.ResetDbResponse;
+import com.snodgrass.fifa_api.dto.response.SimulationResponse;
 import com.snodgrass.fifa_api.dto.response.TeamDetailResponse;
 import com.snodgrass.fifa_api.model.enums.ResetMode;
 import com.snodgrass.fifa_api.service.EventService;
@@ -29,6 +31,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/test")
@@ -43,9 +47,9 @@ public class TestController {
     private String testSchema;
 
     @Operation(summary = "Reset test database from template or production schema",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to allow this write operation.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to allow this write operation.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "200", description = "Test database reset completed")
     @ApiResponse(responseCode = "400", description = "Invalid reset mode")
     @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
@@ -63,10 +67,10 @@ public class TestController {
     }
 
     @Operation(summary = "Create a new team (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                + "Requests without this header will be rejected with 403 Forbidden.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "201", description = "Team created successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
     @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
@@ -78,10 +82,10 @@ public class TestController {
     }
 
     @Operation(summary = "Update an existing team (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                + "Requests without this header will be rejected with 403 Forbidden.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "200", description = "Team updated successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
     @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
@@ -96,10 +100,10 @@ public class TestController {
     }
 
     @Operation(summary = "Delete a team (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                + "Requests without this header will be rejected with 403 Forbidden.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "204", description = "Team deleted successfully")
     @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
     @ApiResponse(responseCode = "404", description = "Team not found")
@@ -112,10 +116,10 @@ public class TestController {
     }
 
     @Operation(summary = "Create a new event (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                + "Requests without this header will be rejected with 403 Forbidden.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "201", description = "Event created successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
     @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
@@ -127,10 +131,10 @@ public class TestController {
     }
 
     @Operation(summary = "Update an existing event (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                + "Requests without this header will be rejected with 403 Forbidden.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "200", description = "Event updated successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
     @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
@@ -144,10 +148,10 @@ public class TestController {
     }
 
     @Operation(summary = "Delete an event (test database only)",
-            description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
-                    + "Requests without this header will be rejected with 403 Forbidden.",
-            parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true,
-                    description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database. "
+                + "Requests without this header will be rejected with 403 Forbidden.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
     @ApiResponse(responseCode = "204", description = "Event deleted successfully")
     @ApiResponse(responseCode = "403", description = "Missing or invalid " + ApiHeaders.TEST_HEADER + " header")
     @ApiResponse(responseCode = "404", description = "Event not found")
@@ -156,5 +160,21 @@ public class TestController {
         log.debug("DELETE /api/test/events/{} - Deleting event", id);
         eventService.deleteEvent(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Run a simulation (test database only)",
+        description = "Requires the " + ApiHeaders.TEST_HEADER + ": " + ApiHeaders.TEST_HEADER_VALUE + " header to target the test database.",
+        parameters = @Parameter(name = ApiHeaders.TEST_HEADER, in = ParameterIn.HEADER, required = true, example = ApiHeaders.TEST_HEADER_VALUE,
+                description = "Must be '" + ApiHeaders.TEST_HEADER_VALUE + "' to enable write operations on the test database"))
+    @PostMapping("/simulation/run")
+    public ResponseEntity<SimulationResponse> runSimulation(@Valid @RequestBody SimulationRequest simulationRequest) {
+        log.debug("POST /api/test/simulation/run - Running simulation");
+        return ResponseEntity.ok(new SimulationResponse(
+                simulationRequest.targetStage(),
+                simulationRequest.completionStatus(),
+                0,
+                List.of(),
+                simulationRequest.seed()
+        ));
     }
 }

--- a/src/main/java/com/snodgrass/fifa_api/dto/request/SimulationRequest.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/request/SimulationRequest.java
@@ -1,0 +1,15 @@
+package com.snodgrass.fifa_api.dto.request;
+
+import com.snodgrass.fifa_api.model.enums.SimulationCompletionStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+import jakarta.validation.constraints.NotNull;
+
+public record SimulationRequest(
+        @NotNull
+        Stage targetStage,
+
+        @NotNull
+        SimulationCompletionStatus completionStatus,
+
+        Long seed
+) {}

--- a/src/main/java/com/snodgrass/fifa_api/dto/response/SimulationResponse.java
+++ b/src/main/java/com/snodgrass/fifa_api/dto/response/SimulationResponse.java
@@ -1,0 +1,14 @@
+package com.snodgrass.fifa_api.dto.response;
+
+import com.snodgrass.fifa_api.model.enums.SimulationCompletionStatus;
+import com.snodgrass.fifa_api.model.enums.Stage;
+
+import java.util.List;
+
+public record SimulationResponse(
+        Stage targetStage,
+        SimulationCompletionStatus completionStatus,
+        int simulatedMatchCount,
+        List<Stage> stagesTouched,
+        long seedUsed
+) { }

--- a/src/main/java/com/snodgrass/fifa_api/model/enums/SimulationCompletionStatus.java
+++ b/src/main/java/com/snodgrass/fifa_api/model/enums/SimulationCompletionStatus.java
@@ -1,0 +1,6 @@
+package com.snodgrass.fifa_api.model.enums;
+
+public enum  SimulationCompletionStatus {
+    HALFWAY,
+    COMPLETE
+}


### PR DESCRIPTION
- Added `SimulationCompletionStatus` enum for the two states that can be called in a simulation (so halfway through Group Stage, Group Stage completed, etc)
- Added `SimulationRequest` dto
- Added `SimulationResponse` dto
    - Added `stagesTouched` -> may revisit if that is needed
- Added `runSimulation` to the `TestController`
    - Bare bones, just returns the response with the request data at the moment
    - Check if error was returned when trying to send in a null targetStage or completeStatus
- Updated code formatting for the controllers
- Added example to the parameter list when `X-DB-STATE` is involved so it is easier to use on Swagger docs
- closes #27 